### PR TITLE
resolves #3 plain text diagram in GET requests

### DIFF
--- a/server/src/main/java/io/kroki/server/service/DiagramHandler.java
+++ b/server/src/main/java/io/kroki/server/service/DiagramHandler.java
@@ -52,7 +52,12 @@ public class DiagramHandler {
       }
       String sourceEncoded = request.getParam("source_encoded");
       try {
-        String sourceDecoded = service.getSourceDecoder().decode(sourceEncoded);
+        String sourceDecoded;
+        if (sourceEncoded.startsWith("plain:")) {
+          sourceDecoded = sourceEncoded.substring("plain:".length(), sourceEncoded.length());
+        } else {
+          sourceDecoded = service.getSourceDecoder().decode(sourceEncoded);
+        }
         convert(routingContext, sourceDecoded, serviceName, fileFormat);
       } catch (DecodeException e) {
         routingContext.fail(new BadRequestException(e.getMessage(), e));


### PR DESCRIPTION
Using the syntax `/<diagram_type>/<output_type>/plain:<diagram_source>`

resolves #3