### PR TITLE
Add Travis to project

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: java
+
 jdk: openjdk12
+
+install: true
 
 script:
   - make installLocalDependencies

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: java
+jdk: openjdk12
 
 script:
   - make installLocalDependencies

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: java
+
+script:
+  - make installLocalDependencies
+  - make buildServer


### PR DESCRIPTION
Travis does the following:

- installs the dependencies
- builds the project with `maven`

The selected JDK is OpenJDK 12 but it can be changed for a lower version if needed.

I would have liked to add containers builds to the CI but I did not manage to build them locally for testing.

I hope it helps. Thanks in advance for your feedback.