### PR TITLE
Fix svgbob container build and add build to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: java
 
+services:
+  - docker
+
 jdk: openjdk12
 
 install: true
@@ -7,3 +10,4 @@ install: true
 script:
   - make installLocalDependencies
   - make buildServer
+  - make buildDockerImages

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ buildDockerImages:
 
 tagDockerImages:
 	docker tag kroki-builder-static-erd:latest kroki-builder-static-erd:0.2.0.0
-	docker tag kroki-builder-static-svgbob:latest kroki-builder-static-svgbob:0.4.1
+	docker tag kroki-builder-static-svgbob:latest kroki-builder-static-svgbob:0.4.2
 	docker tag kroki-builder-nomnoml:latest kroki-builder-nomnoml:0.6.1
 
 showExamples:

--- a/docs/modules/ROOT/pages/architecture.adoc
+++ b/docs/modules/ROOT/pages/architecture.adoc
@@ -45,7 +45,7 @@ The Docker image contains the following diagrams libraries out-of-the-box:
 //|Java library (depends on GraphViz)
 
 |https://github.com/ivanceras/svgbob[Svgbob]
-|0.4.1
+|0.4.2
 //|Binary `/rust/bin/svgbob`
 
 |https://github.com/umlet/umlet[UMlet]

--- a/server/ops/docker/build-static-svgbob
+++ b/server/ops/docker/build-static-svgbob
@@ -1,13 +1,4 @@
 # build static executable binary
 FROM ekidd/rust-musl-builder
 
-RUN git clone https://github.com/ivanceras/svgbob.git /home/rust/src
-
-RUN sudo chown -R rust:rust .
-
-WORKDIR /home/rust/src/svgbob_cli
-
-# version 0.4.1
-RUN git checkout 43fb0364e989d0e9a7656b148c947d47cc769622
-
-RUN cargo build --release
+RUN cargo install --version 0.4.2 svgbob_cli

--- a/server/ops/docker/jdk8-alpine/Dockerfile
+++ b/server/ops/docker/jdk8-alpine/Dockerfile
@@ -1,8 +1,8 @@
 FROM openjdk:8u191-jdk-alpine3.8
 
-COPY --from=kroki-builder-static-svgbob:0.4.1 /home/rust/src/svgbob_cli/target/x86_64-unknown-linux-musl/release/svgbob /rust/bin/svgbob
-COPY --from=kroki-builder-static-erd:0.2.0.0 /root/.local/bin/erd /haskell/bin/erd
-COPY --from=kroki-builder-nomnoml:0.6.1-alpine /app/app.bin /node/bin/nomnoml
+COPY --from=kroki-builder-static-svgbob:latest /home/rust/.cargo/bin/svgbob /rust/bin/svgbob
+COPY --from=kroki-builder-static-erd:latest /root/.local/bin/erd /haskell/bin/erd
+COPY --from=kroki-builder-nomnoml:latest /app/app.bin /node/bin/nomnoml
 
 RUN apk add --update --no-cache \
            graphviz \

--- a/server/src/main/java/io/kroki/server/service/HelloHandler.java
+++ b/server/src/main/java/io/kroki/server/service/HelloHandler.java
@@ -38,7 +38,7 @@ public class HelloHandler {
       serviceVersions.add(new ServiceVersion("nwdiag", "1.0.4"));
       serviceVersions.add(new ServiceVersion("plantuml", "1.2019.9"));
       serviceVersions.add(new ServiceVersion("seqdiag", "0.9.6"));
-      serviceVersions.add(new ServiceVersion("svgbob", "0.4.1"));
+      serviceVersions.add(new ServiceVersion("svgbob", "0.4.2"));
       serviceVersions.add(new ServiceVersion("umlet", "14.3.0"));
       String versionsTable = generateVersionsTable(serviceVersions);
       routingContext


### PR DESCRIPTION
# Changes

- Updated `svgbob` from `0.4.1` to `0.4.2`
- `svgbob` installation is now done using `cargo` instead of a `git clone`
- Added container build to Travis Continuous Integration

Thanks in advance for your feedback.