### PR TITLE
resolves #49 introduces a safe mode

### DIFF
--- a/docs/modules/setup/pages/manual-install.adoc
+++ b/docs/modules/setup/pages/manual-install.adoc
@@ -38,10 +38,28 @@ java -DKROKI_PORT=1234 -jar kroki-server.jar
 Kroki can be configured using environment variables or Java system properties.
 We've already seen how to change the port using `KROKI_PORT`, let's find out how to configure diagram binary paths.
 
+=== Safe Mode
+
+Kroki provides security levels that restrict access to files on the file system and on the network.
+Each level includes the restrictions enabled in the prior security level.
+
+- `UNSAFE`: disables any security features.
+- `SECURE`: prevents attempts to read files from the file system or from the network.
+
+By default, Kroki is running in `SECURE` mode.
+
+While running in `SECURE` mode, Kroki will prevent PlantUML from including files using the `!include` or `!includeurl` directive.
+If you want to enable this feature, you can set the safe mode using the environment variable `KROKI_SAFE_MODE`:
+
+[source,java-cli]
+java -DKROKI_SAFE_MODE=unsafe -jar kroki-server.jar
+
+NOTE: The value is case insensitive, so both `UNSAFE` and `unsafe` will work.
+
 === Diagram Binary Paths
 
 Kroki depends on external binaries to generate images.
-By default Kroki will locate these binaries in the `PATH` environment variable.
+By default, Kroki will locate these binaries in the `PATH` environment variable.
 
 In case you've installed a diagram library in a way where the executable is not in the `PATH`,
 you can override its location manually using an environment variable or a Java system property:

--- a/server/ops/docker/jdk11-alpine/Dockerfile
+++ b/server/ops/docker/jdk11-alpine/Dockerfile
@@ -4,6 +4,7 @@ COPY --from=kroki-builder-static-svgbob:0.4.1 /home/rust/src/svgbob_cli/target/x
 COPY --from=kroki-builder-static-erd:0.2.0.0 /root/.local/bin/erd /haskell/bin/erd
 COPY --from=kroki-builder-nomnoml:0.6.1 /app/app.bin /node/bin/nomnoml
 
+ENV KROKI_SAFE_MODE=secure
 ENV KROKI_SVGBOB_BIN_PATH=/rust/bin/svgbob
 ENV KROKI_ERD_BIN_PATH=/haskell/bin/erd
 ENV KROKI_DOT_BIN_PATH=/usr/bin/dot

--- a/server/ops/docker/jdk11-slim-stretch/Dockerfile
+++ b/server/ops/docker/jdk11-slim-stretch/Dockerfile
@@ -4,6 +4,7 @@ COPY --from=kroki-builder-static-svgbob:0.4.1 /home/rust/src/svgbob_cli/target/x
 COPY --from=kroki-builder-static-erd:0.2.0.0 /root/.local/bin/erd /haskell/bin/erd
 COPY --from=kroki-builder-nomnoml:0.6.1 /app/app.bin /node/bin/nomnoml
 
+ENV KROKI_SAFE_MODE=secure
 ENV KROKI_SVGBOB_BIN_PATH=/rust/bin/svgbob
 ENV KROKI_ERD_BIN_PATH=/haskell/bin/erd
 ENV KROKI_DOT_BIN_PATH=/usr/bin/dot

--- a/server/ops/docker/jdk8-alpine/Dockerfile
+++ b/server/ops/docker/jdk8-alpine/Dockerfile
@@ -15,6 +15,7 @@ COPY ops/docker/ld-musl-x86_64.path /etc/ld-musl-x86_64.path
 
 COPY ops/docker/logback.xml /etc/logback.xml
 
+ENV KROKI_SAFE_MODE=secure
 ENV KROKI_SVGBOB_BIN_PATH=/rust/bin/svgbob
 ENV KROKI_ERD_BIN_PATH=/haskell/bin/erd
 ENV KROKI_DOT_BIN_PATH=/usr/bin/dot

--- a/server/src/main/java/io/kroki/server/Server.java
+++ b/server/src/main/java/io/kroki/server/Server.java
@@ -71,8 +71,8 @@ public class Server extends AbstractVerticle {
       .allowedMethods(allowedMethods));
 
     DiagramRegistry registry = new DiagramRegistry(router, bodyHandler);
-    registry.register(new Plantuml(), "plantuml");
-    registry.register(new C4Plantuml(), "c4plantuml");
+    registry.register(new Plantuml(config), "plantuml");
+    registry.register(new C4Plantuml(config), "c4plantuml");
     registry.register(new Ditaa(), "ditaa");
     registry.register(new Blockdiag(vertx, config), "blockdiag", "seqdiag", "actdiag", "nwdiag", "packetdiag", "rackdiag");
     registry.register(new Umlet(vertx), "umlet");

--- a/server/src/main/java/io/kroki/server/security/SafeMode.java
+++ b/server/src/main/java/io/kroki/server/security/SafeMode.java
@@ -1,0 +1,15 @@
+package io.kroki.server.security;
+
+public enum SafeMode {
+  UNSAFE,
+  SECURE;
+
+  public static SafeMode get(String value, SafeMode def) {
+    for (SafeMode safeMode : values()) {
+      if (safeMode.name().equalsIgnoreCase(value)) {
+        return safeMode;
+      }
+    }
+    return def;
+  }
+}

--- a/server/src/test/java/io/kroki/server/security/SafeModeTest.java
+++ b/server/src/test/java/io/kroki/server/security/SafeModeTest.java
@@ -1,0 +1,31 @@
+package io.kroki.server.security;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SafeModeTest {
+
+  @Test
+  void should_return_default_value() {
+    assertThat(SafeMode.get("yolo", SafeMode.UNSAFE)).isEqualTo(SafeMode.UNSAFE);
+    assertThat(SafeMode.get("yolo", SafeMode.SECURE)).isEqualTo(SafeMode.SECURE);
+  }
+
+  @Test
+  void should_get_safe_mode_case_insensitive() {
+    assertThat(SafeMode.get("unsafe", null)).isEqualTo(SafeMode.UNSAFE);
+    assertThat(SafeMode.get("Unsafe", null)).isEqualTo(SafeMode.UNSAFE);
+    assertThat(SafeMode.get("UNSAFE", null)).isEqualTo(SafeMode.UNSAFE);
+    assertThat(SafeMode.get("secure", null)).isEqualTo(SafeMode.SECURE);
+    assertThat(SafeMode.get("SeCuRE", null)).isEqualTo(SafeMode.SECURE);
+    assertThat(SafeMode.get("SECURE", null)).isEqualTo(SafeMode.SECURE);
+  }
+
+  @Test
+  void should_be_null_safe() {
+    assertThat(SafeMode.get(null, SafeMode.SECURE)).isEqualTo(SafeMode.SECURE);
+    assertThat(SafeMode.get("", SafeMode.SECURE)).isEqualTo(SafeMode.SECURE);
+    assertThat(SafeMode.get("   ", SafeMode.SECURE)).isEqualTo(SafeMode.SECURE);
+  }
+}


### PR DESCRIPTION
The safe mode restricts access to files on the file system and on the network.
PlantUML `!include` directive can be enabled using `KROKI_SAFE_MODE=unsafe`.