### PR TITLE
Expose supporting containers internally, not publicly

### DIFF
--- a/docs/modules/setup/pages/install.adoc
+++ b/docs/modules/setup/pages/install.adoc
@@ -116,12 +116,12 @@ services:
      - "8000:8000"
  blockdiag:
    image: yuzutech/kroki-blockdiag
-   ports:
-     - "8001:8001"
+   expose:
+     - "8001"
  mermaid:
    image: yuzutech/kroki-mermaid
-   ports:
-     - "8002:8002"
+   expose:
+     - "8002"
 ```
 
 [source,docker-cli]


### PR DESCRIPTION
Just a minor thing, but there's no particular reason to publicly expose the supporting container ports (which is what the `ports` directive does). `expose` only exposes the ports to other containers in the same docker network.