### PR TITLE
Migrate tests to GitHub Actions

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -13,7 +13,6 @@ jobs:
     runs-on: ubuntu-18.04
 
     steps:
-    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v2
     - name: Install python 3.8.1
       uses: gabrielfalcao/pyenv-action@v5

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,0 +1,68 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - '*'
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  test-blockdiag:
+    runs-on: ubuntu-18.04
+
+    steps:
+    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+    - uses: actions/checkout@v2
+    - name: Install python 3.8.1
+      uses: gabrielfalcao/pyenv-action@v5
+      with:
+        default: 3.8.1
+        command: pip install -U pip  # upgrade pip after installing python
+
+    - name: Create virtualenv for python 3.8.1
+      run: pyenv local 3.8.1
+
+    - name: Install BlockDiag
+      run: make installBlockDiag
+
+    - name: Test BlockDiag
+      run: make testBlockDiag
+
+  test-containers:
+    runs-on: ubuntu-18.04
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up JDK 12
+      uses: actions/setup-java@v1
+      with:
+        java-version: 12
+
+    - name: Install Java dependencies
+      run: make installLocalDependencies
+
+    - name: Build Java server
+      run: make buildServer
+
+    - name: Setup Docker
+      uses: docker-practice/actions-setup-docker@master
+      with:
+        docker_version: 19.03.8
+        docker_channel: stable
+
+    - name: Build container images
+      run: make buildDockerImages
+
+    - name: 'Setup Node.js 12'
+      uses: actions/setup-node@v1
+      with:
+        node-version: 12.x
+
+    - name: Install Node dependencies
+      run: npm install
+
+    - name: Run smoke tests
+      run: make smokeTests

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -29,7 +29,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Set up JDK 12
+    - name: Set up JDK 11
       uses: actions/setup-java@v1
       with:
         java-version: 11

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -39,7 +39,7 @@ jobs:
     - name: Set up JDK 12
       uses: actions/setup-java@v1
       with:
-        java-version: 12
+        java-version: 11
 
     - name: Install Java dependencies
       run: make installLocalDependencies

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,12 +1,6 @@
 name: CI
 
-on:
-  push:
-    branches:
-      - '*'
-  pull_request:
-    branches:
-      - master
+on: [push, pull_request]
 
 jobs:
   test-blockdiag:


### PR DESCRIPTION
- Tests have been migrated to GitHub Actions
- Tests are split in 2 jobs:
  - BlockDiag tests (approximately: 2 minutes of build time)
  - containers building and smoke testing (approximately: 19 minutes of build time)
- Travis CI configuration is still there but it can be removed once the «go» to GitHub Action has been decided

I hope it satisfies the needs specified in #165.

Thanks for your feedback.