### PR TITLE
Use a simpler setup for Docker

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -42,7 +42,7 @@ jobs:
 
     - name: Setup Docker
       # taken from https://github.com/docker/github-actions/blob/0f18e2abad9a4ac2963d2516246787375b5ec917/Dockerfile#L32
-      run: curl -fL https://download.docker.com/linux/static/stable/x86_64/docker-19.03.8.tgz | tar xzO docker/docker > /usr/bin/docker && chmod +x /usr/bin/docker
+      run: curl -fL https://download.docker.com/linux/static/stable/x86_64/docker-19.03.8.tgz | tar xzO docker/docker > docker && sudo mv -f docker /usr/bin/docker && sudo chmod +x /usr/bin/docker
 
     - name: Build container images
       run: make buildDockerImages

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -41,10 +41,8 @@ jobs:
       run: make buildServer
 
     - name: Setup Docker
-      uses: docker-practice/actions-setup-docker@master
-      with:
-        docker_version: 19.03.8
-        docker_channel: stable
+      # taken from https://github.com/docker/github-actions/blob/0f18e2abad9a4ac2963d2516246787375b5ec917/Dockerfile#L32
+      run: curl -fL https://download.docker.com/linux/static/stable/x86_64/docker-19.03.8.tgz | tar xzO docker/docker > /usr/bin/docker && chmod +x /usr/bin/docker
 
     - name: Build container images
       run: make buildDockerImages


### PR DESCRIPTION
`actions-setup-docker` seems unstable/heavyweight and had failed quite a lot recently so trying a new approach taken from the "official" Docker GitHub Actions repository: https://github.com/docker/github-actions