### PR TITLE
Do not use the embedded mode in bytefield

### DIFF
--- a/bytefield/index.js
+++ b/bytefield/index.js
@@ -9,7 +9,7 @@ function convert () {
   if (source === '') {
     return
   }
-  process.stdout.write(bytefieldProcessor(source, { embedded: true }))
+  process.stdout.write(bytefieldProcessor(source))
 }
 
 const [ , , ...args ] = process.argv;


### PR DESCRIPTION
Otherwise the namespaces will be missing and the browser won't show the image when served directly using "image/svg+xml" content-type.