### PR TITLE
Allow configuration of PlantUML includes

### DIFF
--- a/server/README.adoc
+++ b/server/README.adoc
@@ -55,7 +55,7 @@ When one of the above library is requested, Kroki server will delegate the call.
 
 ==== PlantUML include files
 
-As PlantUML syntax includes pre-processor directives that have the potential to access external resources, serving live content from Kroki server is only recommended when using the dfeault settings of `KROKI_SAFE_MODE=SECURE` and `KROKI_PLANTUML_ALLOW_INCLUDE=false`.
+As PlantUML syntax includes pre-processor directives that have the potential to access external resources, serving live content from Kroki server is only recommended when using the default settings of `KROKI_SAFE_MODE=SECURE` and `KROKI_PLANTUML_ALLOW_INCLUDE=false`.
 
 If you are using Kroki server for offline image generation as part of your build tool chain, you may be able to change these defaults although it is not recommended.
 
@@ -79,5 +79,4 @@ If you don't want to use the Docker image, you will need to install all the depe
 * GraphViz: https://graphviz.gitlab.io/download/
 * Erd: https://github.com/BurntSushi/erd
 * Svgbob: https://github.com/ivanceras/svgbob
-
 

--- a/server/README.adoc
+++ b/server/README.adoc
@@ -28,6 +28,10 @@ KROKI_DOT_BIN_PATH:: Path to the `dot` binary (provided by GraphViz)
 KROKI_NOMNOML_BIN_PATH:: Path to the `nomnoml` binary
 KROKI_BLOCKDIAG_HOST:: The host of the blockdiag server
 KROKI_BLOCKDIAG_PORT:: The port of the blockdiag server
+KROKI_SAFE_MODE:: Either `SECURE` (default) or `UNSAFE`. Determines whether to sanitize requests for formats that allow including external content
+KROKI_PLANTUML_INCLUDE_PATH:: The include path to set for PlantUML.
+KROKI_PLANTUML_INCLUDE_WHITELIST:: The name of a file that consists of a list or regexes for valid includes.
+KROKI_PLANTUML_ALLOW_INCLUDE:: Either `false` (default) or `true`. Determines if PlantUML will fetch `!include` directives that reference external URLs
 
 === Image
 
@@ -48,6 +52,24 @@ To keep the Docker image as small as possible, the following libraries are provi
  * RackDiag
 
 When one of the above library is requested, Kroki server will delegate the call.
+
+==== PlantUML include files
+
+As PlantUML syntax includes pre-processor directives that have the potential to access external resources, serving live content from Kroki server is only recommended when using the dfeault settings of `KROKI_SAFE_MODE=SECURE` and `KROKI_PLANTUML_ALLOW_INCLUDE=false`.
+
+If you are using Kroki server for offline image generation as part of your build tool chain, you may be able to change these defaults although it is not recommended.
+
+The recommended pattern for handling includes is to either extend the docker image or bind mount a directory containing the files you wish to include and then set the `KROKI_PLANTUML_INCLUDE_PATH` environment variable.
+
+For example:
+
+[source,bash]
+----
+$ mkdir example-lib
+$ printf "@startuml\nBob->Alice\n@enduml\n" > example-lib/bob.puml
+$ sudo docker run --publish=8000:8000 -v $(pwd)/example-lib:/example-lib -e KROKI_PLANTUML_INCLUDE_PATH=/example-lib yuzutech/kroki:latest
+$ curl http://localhost:8000/plantuml/svstartuml\n!include bob.puml\nAlice -> Bob\n@enduml' | python -c "import sys; import base64; import zlib; print(base64.urlsafe_b64encode(zlib.compress(sys.stdin.read(), 9)))")
+----
 
 == Manual install
 

--- a/server/README.adoc
+++ b/server/README.adoc
@@ -28,9 +28,27 @@ KROKI_DOT_BIN_PATH:: Path to the `dot` binary (provided by GraphViz)
 KROKI_NOMNOML_BIN_PATH:: Path to the `nomnoml` binary
 KROKI_BLOCKDIAG_HOST:: The host of the blockdiag server
 KROKI_BLOCKDIAG_PORT:: The port of the blockdiag server
-KROKI_SAFE_MODE:: Either `SECURE` (default) or `UNSAFE`. Determines whether to sanitize requests for formats that allow including external content
+KROKI_SAFE_MODE:: One of:
++
+--
+`SECURE`:: (default) Paranoid sanitization of requests before passing to image server.
+`SAFE`:: Assume the image servers secure mode request sanitization is sufficient
+`UNSAFE`:: Run the image servers without request sanitization.
+--
++
+[NOTE]
+--
+Some of the image servers allow referencing external entities by URL or accessing resources from the filesystem.
+
+For example PlantUML allows the `!import` directive to pull fragments from the filesystem or a remote URL or the standard library.
+
+It is the responsibility of the upstream codebases to ensure that they can be safely used without risk.
+Because Kroki does not perform code review of these servies, our default setting is to be paranoid and block imports unless known safe.
+We encourage anyone running their own Kroki server to review the services security settings and select the security mode appropriate for their use case.
+--
 KROKI_PLANTUML_INCLUDE_PATH:: The include path to set for PlantUML.
 KROKI_PLANTUML_INCLUDE_WHITELIST:: The name of a file that consists of a list or regexes for valid includes.
+KROKI_PLANTUML_INCLUDE_WHITELIST_0, KROKI_PLANTUML_INCLUDE_WHITELIST_1, ... KROKI_PLANTUML_INCLUDE_WHITELIST___N__:: One regex to add to the include whitelist per environment variable. Search will stop at the first empty or undefined integer number.
 KROKI_PLANTUML_ALLOW_INCLUDE:: Either `false` (default) or `true`. Determines if PlantUML will fetch `!include` directives that reference external URLs
 
 === Image

--- a/server/README.adoc
+++ b/server/README.adoc
@@ -85,7 +85,7 @@ For example:
 ----
 $ mkdir example-lib
 $ printf "@startuml\nBob->Alice\n@enduml\n" > example-lib/bob.puml
-$ sudo docker run --publish=8000:8000 -v $(pwd)/example-lib:/example-lib -e KROKI_PLANTUML_INCLUDE_PATH=/example-lib yuzutech/kroki:latest
+$ sudo docker run --publish=8000:8000 -v $(pwd)/example-lib:/example-lib -e KROKI_SAFE_MODE=SAFE -e KROKI_PLANTUML_INCLUDE_PATH=/example-lib yuzutech/kroki:latest
 $ curl http://localhost:8000/plantuml/svg/$(printf '@startuml\n!include bob.puml\nAlice -> Bob\n@enduml' | python -c "import sys; import base64; import zlib; print(base64.urlsafe_b64encode(zlib.compress(sys.stdin.read(), 9)))")
 ----
 
@@ -97,4 +97,3 @@ If you don't want to use the Docker image, you will need to install all the depe
 * GraphViz: https://graphviz.gitlab.io/download/
 * Erd: https://github.com/BurntSushi/erd
 * Svgbob: https://github.com/ivanceras/svgbob
-

--- a/server/README.adoc
+++ b/server/README.adoc
@@ -31,23 +31,23 @@ KROKI_BLOCKDIAG_PORT:: The port of the blockdiag server
 KROKI_SAFE_MODE:: One of:
 +
 --
-`SECURE`:: (default) Paranoid sanitization of requests before passing to image server.
-`SAFE`:: Assume the image servers secure mode request sanitization is sufficient
-`UNSAFE`:: Run the image servers without request sanitization.
+`SECURE`:: (default) Paranoid sanitization of requests before passing to the diagram library.
+`SAFE`:: Assume the diagram libraries secure mode request sanitization is sufficient
+`UNSAFE`:: Run the diagram libraries without request sanitization.
 --
 +
 [NOTE]
 --
-Some of the image servers allow referencing external entities by URL or accessing resources from the filesystem.
+Some of the diagram libraries allow referencing external entities by URL or accessing resources from the filesystem.
 
 For example PlantUML allows the `!import` directive to pull fragments from the filesystem or a remote URL or the standard library.
 
 It is the responsibility of the upstream codebases to ensure that they can be safely used without risk.
-Because Kroki does not perform code review of these servies, our default setting is to be paranoid and block imports unless known safe.
+Because Kroki does not perform code review of these services, our default setting is to be paranoid and block imports unless known safe.
 We encourage anyone running their own Kroki server to review the services security settings and select the security mode appropriate for their use case.
 --
 KROKI_PLANTUML_INCLUDE_PATH:: The include path to set for PlantUML.
-KROKI_PLANTUML_INCLUDE_WHITELIST:: The name of a file that consists of a list or regexes for valid includes.
+KROKI_PLANTUML_INCLUDE_WHITELIST:: The name of a file that consists of a list of Java regular expressions for valid includes.
 KROKI_PLANTUML_INCLUDE_WHITELIST_0, KROKI_PLANTUML_INCLUDE_WHITELIST_1, ... KROKI_PLANTUML_INCLUDE_WHITELIST___N__:: One regex to add to the include whitelist per environment variable. Search will stop at the first empty or undefined integer number.
 KROKI_PLANTUML_ALLOW_INCLUDE:: Either `false` (default) or `true`. Determines if PlantUML will fetch `!include` directives that reference external URLs
 

--- a/server/README.adoc
+++ b/server/README.adoc
@@ -68,7 +68,7 @@ For example:
 $ mkdir example-lib
 $ printf "@startuml\nBob->Alice\n@enduml\n" > example-lib/bob.puml
 $ sudo docker run --publish=8000:8000 -v $(pwd)/example-lib:/example-lib -e KROKI_PLANTUML_INCLUDE_PATH=/example-lib yuzutech/kroki:latest
-$ curl http://localhost:8000/plantuml/svstartuml\n!include bob.puml\nAlice -> Bob\n@enduml' | python -c "import sys; import base64; import zlib; print(base64.urlsafe_b64encode(zlib.compress(sys.stdin.read(), 9)))")
+$ curl http://localhost:8000/plantuml/svg/$(printf '@startuml\n!include bob.puml\nAlice -> Bob\n@enduml' | python -c "import sys; import base64; import zlib; print(base64.urlsafe_b64encode(zlib.compress(sys.stdin.read(), 9)))")
 ----
 
 == Manual install

--- a/server/src/main/java/io/kroki/server/security/SafeMode.java
+++ b/server/src/main/java/io/kroki/server/security/SafeMode.java
@@ -1,7 +1,11 @@
 package io.kroki.server.security;
 
 public enum SafeMode {
+  /** Do not apply any security checking. */
   UNSAFE,
+  /** Let each service apply its own internal security checks. */
+  SAFE,
+  /** Do not trust service internal security checks. */
   SECURE;
 
   public static SafeMode get(String value, SafeMode def) {

--- a/server/src/main/java/io/kroki/server/security/SafeMode.java
+++ b/server/src/main/java/io/kroki/server/security/SafeMode.java
@@ -2,11 +2,17 @@ package io.kroki.server.security;
 
 public enum SafeMode {
   /** Do not apply any security checking. */
-  UNSAFE,
+  UNSAFE(0),
   /** Let each service apply its own internal security checks. */
-  SAFE,
+  SAFE(1),
   /** Do not trust service internal security checks. */
-  SECURE;
+  SECURE(10);
+
+  public final int value;
+
+  SafeMode(int value) {
+    this.value = value;
+  }
 
   public static SafeMode get(String value, SafeMode def) {
     for (SafeMode safeMode : values()) {

--- a/server/src/main/java/io/kroki/server/service/Plantuml.java
+++ b/server/src/main/java/io/kroki/server/service/Plantuml.java
@@ -50,11 +50,11 @@ public class Plantuml implements DiagramService {
   /**
    * Extracts the target of the include/includeurl/includesub directive. The first and only matching group is the
    * target.
-   * <p />
+   * <p/>
    * We ignore any subpart/sub-document identifiers, i.e. anything after a {@code !} in the include name
-   * <p />
+   * <p/>
    * We ignore any trailing comments on the line, i.e. anything after a {@code #} in the include line
-   * <p />
+   * <p/>
    * Some sample patterns:
    * <ul>
    *   <li>{@code !include &lt;some/stdlib&gt;} includes a file from the stdlib</li>
@@ -247,15 +247,14 @@ public class Plantuml implements DiagramService {
     }
   }
 
-  private static void ignoreInclude(String line, StringBuilder sb, SafeMode safeMode,
-                                    Collection<Pattern> includeWhitelist) {
+  private static void ignoreInclude(String line, StringBuilder sb, SafeMode safeMode, Collection<Pattern> includeWhitelist) {
     Matcher matcher = INCLUDE_RX.matcher(line);
     if (matcher.matches()) {
       String include = matcher.group(1);
       Matcher stdlibPathMatcher = STDLIB_PATH_RX.matcher(include);
       if (stdlibPathMatcher.matches()) {
         String prefix = stdlibPathMatcher.group(1).toLowerCase();
-        if (safeMode != SafeMode.SECURE || STDLIB.contains(prefix)) {
+        if (STDLIB.contains(prefix)) {
           sb.append(line).append("\n");
         }
       } else if (safeMode != SafeMode.SECURE

--- a/server/src/main/java/io/kroki/server/service/Plantuml.java
+++ b/server/src/main/java/io/kroki/server/service/Plantuml.java
@@ -257,44 +257,45 @@ public class Plantuml implements DiagramService {
         if (STDLIB.contains(prefix)) {
           sb.append(line).append("\n");
         }
-      } else if (safeMode != SafeMode.SECURE
-        && !include.startsWith("<") // includes starting with < must only come from stdlib
-        && !include.startsWith("/") && !include.startsWith("\\") // no absolute paths,
-        && !include.startsWith("http://") && !include.startsWith("https://") // no URLs
-        // no path walking
-        && !include.startsWith("../") && !include.contains("/../") && !include.endsWith("/..")
-        && !include.startsWith("..\\") && !include.contains("\\..\\") && !include.endsWith("\\..")
-        && !include.contains("/..\\") && !include.contains("\\../")) {
-        // PlantUML's safety checking will suffice as it will only allow files directly in the include path
+      } else if (safeMode.value < SafeMode.SECURE.value) {
+        if (!include.startsWith("<") // includes starting with < must only come from stdlib
+          && !include.startsWith("/") && !include.startsWith("\\") // no absolute paths,
+          && !include.startsWith("http://") && !include.startsWith("https://") // no URLs
+          // no path walking
+          && !include.startsWith("../") && !include.contains("/../") && !include.endsWith("/..")
+          && !include.startsWith("..\\") && !include.contains("\\..\\") && !include.endsWith("\\..")
+          && !include.contains("/..\\") && !include.contains("\\../")) {
+          // PlantUML's safety checking will suffice as it will only allow files directly in the include path
 
-        // Note: we are relying on the PlantUML include checking algorithm:
-        // * See ImportedFiles#executeInclude and ImportedFiles#executeIncludesub
-        // * !importsub does not work with URLs or the standard library
-        // * Imports that start with `http://` or `https://` are resolved from the URL, that is generally
-        //   unsafe unless you can trust the source of the URL, thus we do not permit here.
-        // * Imports wrapped in `<` and `>` are resolved only from the standard library and thus should be
-        //   a fixed set guarded by `/stdlib/${name}-abx.repx` resources on the classpath, in any case we
-        //   ignore stdlib import validation here
-        // * Absolute imports could refer to any file, so we exclude those, though FileWithSuffix#fileOk()
-        //   should restrict accessible files to only those "approved"
-        // * We only auto-permit "search path" includes that do not attempt search path escaping with `..`
-        // * The import or importsub that we auto-permit will result in a call to ImportedFiles.getFile(...)
-        // * That will iterate the "plantuml.include.path" (note PlantUML is not well designed for embedding
-        //   on this property as the ImportedFiles#INCLUDE_PATH is initialized once on classloading)
-        // * At this point, if the INCLUDE_PATH included say `/example` and the include was `foo/bar.puml`
-        //   and there is a file `/example/foo/bar.puml` then that would stop the search with an `AFileRegular`
-        //   instance. HOWEVER, the return value of ImportedFiles#getFile is guarded by ImportedFiles#isAllowed
-        // * ImportedFiles#isAllowed will only permit AFile instances with the AFile#getSystemFolder() being
-        //   contained in ImportedFiles#INCLUDE_PATH so as AFileRegular#getSystemFolder() always returned the
-        //   parent folder of the file and include of `foo/bar.puml` found on an include path of `/example`
-        //   resolving to `/example/foo/bar.puml` will have a system folder of `/example/foo` which is not
-        //   one of the folders whitelisted in the include path and thus the include will be resolved as not-found
-        //
-        // Effectively only imports that are immediate children of the folders listed in "plantuml.include.path"
-        // are eligible for inlcude (unless OptionFlags.ALLOW_INCLUDE has been set to true)
-        sb.append(line).append("\n");
-      } else if (includeWhitelist.stream().anyMatch(p -> p.matcher(include).matches())) {
-        sb.append(line).append("\n");
+          // Note: we are relying on the PlantUML include checking algorithm:
+          // * See ImportedFiles#executeInclude and ImportedFiles#executeIncludesub
+          // * !importsub does not work with URLs or the standard library
+          // * Imports that start with `http://` or `https://` are resolved from the URL, that is generally
+          //   unsafe unless you can trust the source of the URL, thus we do not permit here.
+          // * Imports wrapped in `<` and `>` are resolved only from the standard library and thus should be
+          //   a fixed set guarded by `/stdlib/${name}-abx.repx` resources on the classpath, in any case we
+          //   ignore stdlib import validation here
+          // * Absolute imports could refer to any file, so we exclude those, though FileWithSuffix#fileOk()
+          //   should restrict accessible files to only those "approved"
+          // * We only auto-permit "search path" includes that do not attempt search path escaping with `..`
+          // * The import or importsub that we auto-permit will result in a call to ImportedFiles.getFile(...)
+          // * That will iterate the "plantuml.include.path" (note PlantUML is not well designed for embedding
+          //   on this property as the ImportedFiles#INCLUDE_PATH is initialized once on classloading)
+          // * At this point, if the INCLUDE_PATH included say `/example` and the include was `foo/bar.puml`
+          //   and there is a file `/example/foo/bar.puml` then that would stop the search with an `AFileRegular`
+          //   instance. HOWEVER, the return value of ImportedFiles#getFile is guarded by ImportedFiles#isAllowed
+          // * ImportedFiles#isAllowed will only permit AFile instances with the AFile#getSystemFolder() being
+          //   contained in ImportedFiles#INCLUDE_PATH so as AFileRegular#getSystemFolder() always returned the
+          //   parent folder of the file and include of `foo/bar.puml` found on an include path of `/example`
+          //   resolving to `/example/foo/bar.puml` will have a system folder of `/example/foo` which is not
+          //   one of the folders whitelisted in the include path and thus the include will be resolved as not-found
+          //
+          // Effectively only imports that are immediate children of the folders listed in "plantuml.include.path"
+          // are eligible for inlcude (unless OptionFlags.ALLOW_INCLUDE has been set to true)
+          sb.append(line).append("\n");
+        } else if (includeWhitelist.stream().anyMatch(p -> p.matcher(include).matches())) {
+          sb.append(line).append("\n");
+        }
       }
     } else {
       sb.append(line).append("\n");

--- a/server/src/main/java/io/kroki/server/service/Plantuml.java
+++ b/server/src/main/java/io/kroki/server/service/Plantuml.java
@@ -42,7 +42,28 @@ public class Plantuml implements DiagramService {
 
   private static final List<FileFormat> SUPPORTED_FORMATS = Arrays.asList(FileFormat.PNG, FileFormat.SVG, FileFormat.JPEG, FileFormat.BASE64, FileFormat.TXT, FileFormat.UTXT);
 
-  private static final Pattern INCLUDE_RX = Pattern.compile("^\\s*!include(?:url)?\\s+(.*)(?:!.*)?");
+  /**
+   * Extracts the target of the include/includeurl/includesub directive. The first and only matching group is the
+   * target.
+   * <p />
+   * We ignore any subpart/sub-document identifiers, i.e. anything after a {@code !} in the include name
+   * <p />
+   * We ignore any trailing comments on the line, i.e. anything after a {@code #} in the include line
+   * <p />
+   * Some sample patterns:
+   * <ul>
+   *   <li>{@code !include &lt;some/stdlib&gt;} includes a file from the stdlib</li>
+   *   <li>{@code !include http://some/url} includes an external resource by URL</li>
+   *   <li>{@code !include /absolute/file/path} includes a file from the filesystem</li>
+   *   <li>{@code !include search-path-file} includes a file on the "plantuml.include.path"</li>
+   *   <li>{@code !include search-path-file!2} includes the 3rd document in a file on the "plantuml.include.path"</li>
+   *   <li>{@code !includesub search-path-file!SUBID} includes the SUBID subpart of a file on the "plantuml.include.path"</li>
+   *   <li>{@code !includeurl http://some/url} deprecated include of an external resource by URL</li>
+   * </ul>
+   *
+   * @see <a href="https://plantuml.com/preprocessing">PlantUML Preprocessing</a>
+   */
+  private static final Pattern INCLUDE_RX = Pattern.compile("^\\s*!include(?:url|sub)?\\s+(.*)(?:!.*)?(?:#.*)?");
   private static final Pattern STDLIB_PATH_RX = Pattern.compile("<([a-zA-Z0-9]+)/[^>]+>");
 
   private final SafeMode safeMode;
@@ -205,16 +226,43 @@ public class Plantuml implements DiagramService {
         if (STDLIB.contains(prefix)) {
           sb.append(line).append("\n");
         }
-      } else {
-        if (!include.startsWith("http://") && !include.startsWith("https://")
-          && !include.startsWith("../") && !include.contains("/../") && !include.endsWith("/..")
-            && !include.startsWith("..\\") && !include.contains("\\..\\") && !include.endsWith("\\..")
-            && !include.contains("/..\\") && !include.contains("\\../")) {
-          // PlantUML's safety checking will suffice as it will only allow files in the include path
-          sb.append(line).append("\n");
-        } else if (includeWhitelist.stream().anyMatch(p -> p.matcher(include).matches())) {
-          sb.append(line).append("\n");
-        }
+      } else if (!include.startsWith("<") // includes starting with < must only come from stdlib
+        && !include.startsWith("/") && !include.startsWith("\\") // no absolute paths,
+        && !include.startsWith("http://") && !include.startsWith("https://") // no URLs
+        // no path walking
+        && !include.startsWith("../") && !include.contains("/../") && !include.endsWith("/..")
+        && !include.startsWith("..\\") && !include.contains("\\..\\") && !include.endsWith("\\..")
+        && !include.contains("/..\\") && !include.contains("\\../")) {
+        // PlantUML's safety checking will suffice as it will only allow files directly in the include path
+
+        // Note: we are relying on the PlantUML include checking algorithm:
+        // * See ImportedFiles#executeInclude and ImportedFiles#executeIncludesub
+        // * !importsub does not work with URLs or the standard library
+        // * Imports that start with `http://` or `https://` are resolved from the URL, that is generally
+        //   unsafe unless you can trust the source of the URL, thus we do not permit here.
+        // * Imports wrapped in `<` and `>` are resolved only from the standard library and thus should be
+        //   a fixed set guarded by `/stdlib/${name}-abx.repx` resources on the classpath, in any case we
+        //   ignore stdlib import validation here
+        // * Absolute imports could refer to any file, so we exclude those, though FileWithSuffix#fileOk()
+        //   should restrict accessible files to only those "approved"
+        // * We only auto-permit "search path" includes that do not attempt search path escaping with `..`
+        // * The import or importsub that we auto-permit will result in a call to ImportedFiles.getFile(...)
+        // * That will iterate the "plantuml.include.path" (note PlantUML is not well designed for embedding
+        //   on this property as the ImportedFiles#INCLUDE_PATH is initialized once on classloading)
+        // * At this point, if the INCLUDE_PATH included say `/example` and the include was `foo/bar.puml`
+        //   and there is a file `/example/foo/bar/puml` then that would stop the search with an `AFileRegular`
+        //   instance. HOWEVER, the return value of ImportedFiles#getFile is guarded by ImportedFiles#isAllowed
+        // * ImportedFiles#isAllowed will only permit AFile instances with the AFile#getSystemFolder() being
+        //   contained in ImportedFiles#INCLUDE_PATH so as AFileRegular#getSystemFolder() always returned the
+        //   parent folder of the file and include of `foo/bar.puml` found on an include path of `/example`
+        //   resolving to `/example/foo/bar.puml` will have a system folder of `/example/foo` which is not
+        //   one of the folders whitelisted in the include path and thus the include will be resolved as not-found
+        //
+        // Effectively only imports that are immediate children of the folders listed in "plantuml.include.path"
+        // are eligible for inlcude (unless OptionFlags.ALLOW_INCLUDE has been set to true)
+        sb.append(line).append("\n");
+      } else if (includeWhitelist.stream().anyMatch(p -> p.matcher(include).matches())) {
+        sb.append(line).append("\n");
       }
     } else {
       sb.append(line).append("\n");

--- a/server/src/main/java/io/kroki/server/service/Plantuml.java
+++ b/server/src/main/java/io/kroki/server/service/Plantuml.java
@@ -107,14 +107,14 @@ public class Plantuml implements DiagramService {
     }
   }
 
-  private static List<Pattern> parseIncludeWhitelist(JsonObject config) {
+  static List<Pattern> parseIncludeWhitelist(JsonObject config) {
     String filename = config.getString("KROKI_PLANTUML_INCLUDE_WHITELIST");
     List<Pattern> result = new ArrayList<>();
     if (filename != null) {
       final Path path = Paths.get(filename);
       if (Files.isRegularFile(path)) {
         try {
-          Files.lines(path).filter(s -> !s.isEmpty()).flatMap(regex -> {
+          Files.lines(path).map(String::trim).filter(s -> !s.isEmpty()).flatMap(regex -> {
             try {
               return Stream.of(Pattern.compile(regex));
             } catch (PatternSyntaxException e) {
@@ -142,7 +142,7 @@ public class Plantuml implements DiagramService {
         logger.warn("Ignoring invalid regex {} from KROKI_PLANTUML_INCLUDE_WHITELIST_{}", regex, i, e);
       }
     }
-    return Collections.emptyList();
+    return result;
   }
 
   @Override

--- a/server/src/main/java/io/kroki/server/service/Plantuml.java
+++ b/server/src/main/java/io/kroki/server/service/Plantuml.java
@@ -118,28 +118,28 @@ public class Plantuml implements DiagramService {
             try {
               return Stream.of(Pattern.compile(regex));
             } catch (PatternSyntaxException e) {
-              logger.warn("Ignoring invalid regex {} in {}", regex, filename, e);
+              logger.warn("Ignoring invalid regex '{}' in '{}'", regex, filename, e);
               return Stream.empty();
             }
           }).forEach(result::add);
         } catch (IOException e) {
-          logger.warn("Unable to read the PlantUML whitelist file: {}", filename, e);
+          logger.warn("Unable to read the PlantUML whitelist file '{}'", filename, e);
           return Collections.emptyList();
         }
       } else {
-        logger.warn("Unable to read the PlantUML whitelist file: {} as it is not a regular file", filename);
+        logger.warn("Unable to read the PlantUML whitelist file '{}' as it is not a regular file", filename);
       }
     }
     for (int i = 0; true; i++) {
       final String regex = config.getString("KROKI_PLANTUML_INCLUDE_WHITELIST_" + i);
-      if (regex == null || regex.isEmpty()) {
+      if (regex == null || regex.trim().isEmpty()) {
         // stop at the first missing index
         break;
       }
       try {
-        result.add(Pattern.compile(regex));
+        result.add(Pattern.compile(regex.trim()));
       } catch (PatternSyntaxException e) {
-        logger.warn("Ignoring invalid regex {} from KROKI_PLANTUML_INCLUDE_WHITELIST_{}", regex, i, e);
+        logger.warn("Ignoring invalid regex '{}' from KROKI_PLANTUML_INCLUDE_WHITELIST_{}", regex.trim(), i, e);
       }
     }
     return result;

--- a/server/src/main/java/io/kroki/server/service/Plantuml.java
+++ b/server/src/main/java/io/kroki/server/service/Plantuml.java
@@ -26,7 +26,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.BufferedReader;
 import java.io.ByteArrayOutputStream;
-import java.io.File;
 import java.io.IOException;
 import java.io.StringReader;
 import java.io.UnsupportedEncodingException;

--- a/server/src/main/java/io/kroki/server/service/Vega.java
+++ b/server/src/main/java/io/kroki/server/service/Vega.java
@@ -12,7 +12,6 @@ import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.RoutingContext;
-
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
@@ -78,9 +77,18 @@ public class Vega implements DiagramService {
   }
 
   private byte[] vega(byte[] source, String format) throws IOException, InterruptedException, IllegalStateException {
+    final String vegaSafeMode;
+    switch (safeMode) {
+      case UNSAFE:
+        vegaSafeMode = "unsafe";
+        break;
+      default:
+        vegaSafeMode = "secure";
+        break;
+    }
     return commander.execute(source, binPath,
       "--output-format=" + format,
-      "--safe-mode=" + safeMode.name().toLowerCase(),
+      "--safe-mode=" + vegaSafeMode,
       "--spec-format=" + specFormat.name().toLowerCase());
   }
 

--- a/server/src/test/java/io/kroki/server/security/SafeModeTest.java
+++ b/server/src/test/java/io/kroki/server/security/SafeModeTest.java
@@ -9,6 +9,7 @@ public class SafeModeTest {
   @Test
   void should_return_default_value() {
     assertThat(SafeMode.get("yolo", SafeMode.UNSAFE)).isEqualTo(SafeMode.UNSAFE);
+    assertThat(SafeMode.get("yolo", SafeMode.SAFE)).isEqualTo(SafeMode.SAFE);
     assertThat(SafeMode.get("yolo", SafeMode.SECURE)).isEqualTo(SafeMode.SECURE);
   }
 
@@ -17,6 +18,9 @@ public class SafeModeTest {
     assertThat(SafeMode.get("unsafe", null)).isEqualTo(SafeMode.UNSAFE);
     assertThat(SafeMode.get("Unsafe", null)).isEqualTo(SafeMode.UNSAFE);
     assertThat(SafeMode.get("UNSAFE", null)).isEqualTo(SafeMode.UNSAFE);
+    assertThat(SafeMode.get("safe", null)).isEqualTo(SafeMode.SAFE);
+    assertThat(SafeMode.get("Safe", null)).isEqualTo(SafeMode.SAFE);
+    assertThat(SafeMode.get("SAFE", null)).isEqualTo(SafeMode.SAFE);
     assertThat(SafeMode.get("secure", null)).isEqualTo(SafeMode.SECURE);
     assertThat(SafeMode.get("SeCuRE", null)).isEqualTo(SafeMode.SECURE);
     assertThat(SafeMode.get("SECURE", null)).isEqualTo(SafeMode.SECURE);

--- a/server/src/test/java/io/kroki/server/security/SafeModeTest.java
+++ b/server/src/test/java/io/kroki/server/security/SafeModeTest.java
@@ -32,4 +32,11 @@ public class SafeModeTest {
     assertThat(SafeMode.get("", SafeMode.SECURE)).isEqualTo(SafeMode.SECURE);
     assertThat(SafeMode.get("   ", SafeMode.SECURE)).isEqualTo(SafeMode.SECURE);
   }
+
+  @Test
+  void safe_mode_are_comparable() {
+    assertThat(SafeMode.UNSAFE.value).isLessThan(SafeMode.SAFE.value);
+    assertThat(SafeMode.UNSAFE.value).isLessThan(SafeMode.SECURE.value);
+    assertThat(SafeMode.SAFE.value).isLessThan(SafeMode.SECURE.value);
+  }
 }

--- a/server/src/test/java/io/kroki/server/service/C4PlantumlServiceTest.java
+++ b/server/src/test/java/io/kroki/server/service/C4PlantumlServiceTest.java
@@ -1,0 +1,31 @@
+package io.kroki.server.service;
+
+import io.kroki.server.security.SafeMode;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class C4PlantumlServiceTest {
+
+  @Test
+  void should_include_c4_puml_file_from_classloader() throws IOException {
+    String diagram = "@startuml\n" +
+      "!include /path/to/c4.puml # comment \n" +
+      "@enduml";
+    String result = C4Plantuml.sanitize(diagram, SafeMode.SECURE);
+    assertThat(result).contains("https://github.com/RicardoNiepel/C4-PlantUML");
+  }
+
+  @Test
+  void should_not_sanitize_in_unsafe_mode() throws IOException {
+    String diagram = "@startuml\n" +
+      "!include /path/to/file.puml # comment \n" +
+      "!include https://foo.bar\n" +
+      "  !includeurl   https://foo.bar\n" +
+      "@enduml\n";
+    String result = C4Plantuml.sanitize(diagram, SafeMode.UNSAFE);
+    assertThat(result).isEqualTo(diagram);
+  }
+}

--- a/server/src/test/java/io/kroki/server/service/PlantumlServiceTest.java
+++ b/server/src/test/java/io/kroki/server/service/PlantumlServiceTest.java
@@ -106,6 +106,15 @@ public class PlantumlServiceTest {
   }
 
   @Test
+  void should_sanitize_include_to_local_file2() throws IOException {
+    String diagram = "@startuml\n" +
+      "!include /etc/password #<aws/common>\n" +
+      "@enduml";
+    String result = Plantuml.sanitize(diagram, SafeMode.SECURE);
+    assertThat(result).isEqualTo("@startuml\n@enduml\n");
+  }
+
+  @Test
   void should_not_sanitize_include_in_unsafe_mode() throws IOException {
     String diagram = "@startuml\n" +
       "!include /foo/bar\n" +
@@ -116,6 +125,17 @@ public class PlantumlServiceTest {
       "@enduml";
     String result = Plantuml.sanitize(diagram, SafeMode.UNSAFE);
     assertThat(result).isEqualTo(diagram);
+  }
+
+  @Test
+  void should_not_sanitize_include_for_search_path_includes() throws IOException {
+    String diagram = "@startuml\n" +
+      "!include bar\n" +
+      "!include foo!1\n" +
+      "!includesub fooBar!BASIC\n" +
+      "@enduml";
+    String result = Plantuml.sanitize(diagram, SafeMode.SECURE);
+    assertThat(result.trim()).isEqualTo(diagram);
   }
 
   @Test

--- a/server/src/test/java/io/kroki/server/service/PlantumlServiceTest.java
+++ b/server/src/test/java/io/kroki/server/service/PlantumlServiceTest.java
@@ -128,13 +128,13 @@ public class PlantumlServiceTest {
   }
 
   @Test
-  void should_not_sanitize_include_for_search_path_includes() throws IOException {
+  void should_not_sanitize_include_for_search_path_includes_in_safe_mode() throws IOException {
     String diagram = "@startuml\n" +
       "!include bar\n" +
       "!include foo!1\n" +
       "!includesub fooBar!BASIC\n" +
       "@enduml";
-    String result = Plantuml.sanitize(diagram, SafeMode.SECURE);
+    String result = Plantuml.sanitize(diagram, SafeMode.SAFE);
     assertThat(result.trim()).isEqualTo(diagram);
   }
 

--- a/server/src/test/java/io/kroki/server/service/PlantumlServiceTest.java
+++ b/server/src/test/java/io/kroki/server/service/PlantumlServiceTest.java
@@ -3,9 +3,16 @@ package io.kroki.server.service;
 import io.kroki.server.error.BadRequestException;
 import io.kroki.server.format.FileFormat;
 import io.kroki.server.security.SafeMode;
+import io.vertx.core.json.JsonObject;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -175,5 +182,132 @@ public class PlantumlServiceTest {
       "     ┌─┴─┐          ┌──┴──┐\n" +
       "     │Bob│          │Alice│\n" +
       "     └───┘          └─────┘\n");
+  }
+
+  @Test
+  void should_return_empty_whitelist_when_config_empty() {
+    Map<String, Object> config = new HashMap<>();
+    List<Pattern> patterns = Plantuml.parseIncludeWhitelist(new JsonObject(config));
+    assertThat(patterns).isEmpty();
+  }
+
+  @Test
+  void should_return_empty_list_when_whitelist_file_empty() throws URISyntaxException {
+    Map<String, Object> config = new HashMap<>();
+    config.put("KROKI_PLANTUML_INCLUDE_WHITELIST", Paths.get(PlantumlServiceTest.class.getResource("/whitelist_empty.txt").toURI()).toString());
+    List<Pattern> patterns = Plantuml.parseIncludeWhitelist(new JsonObject(config));
+    assertThat(patterns).isEmpty();
+  }
+
+  @Test
+  void should_return_empty_list_when_file_does_not_exist() {
+    Map<String, Object> config = new HashMap<>();
+    config.put("KROKI_PLANTUML_INCLUDE_WHITELIST", "missing.txt");
+    List<Pattern> patterns = Plantuml.parseIncludeWhitelist(new JsonObject(config));
+    assertThat(patterns).isEmpty();
+  }
+
+  @Test
+  void should_ignore_invalid_regex_from_whitelist_file() throws URISyntaxException {
+    Map<String, Object> config = new HashMap<>();
+    config.put("KROKI_PLANTUML_INCLUDE_WHITELIST", Paths.get(PlantumlServiceTest.class.getResource("/whitelist_invalid.txt").toURI()).toString());
+    List<Pattern> patterns = Plantuml.parseIncludeWhitelist(new JsonObject(config));
+    assertThat(patterns).isEmpty();
+  }
+
+  @Test
+  void should_ignore_invalid_regex_from_whitelist_file_but_continue() throws URISyntaxException {
+    Map<String, Object> config = new HashMap<>();
+    config.put("KROKI_PLANTUML_INCLUDE_WHITELIST", Paths.get(PlantumlServiceTest.class.getResource("/whitelist_mixed.txt").toURI()).toString());
+    List<Pattern> patterns = Plantuml.parseIncludeWhitelist(new JsonObject(config));
+    assertThat(patterns)
+      .extracting("pattern")
+      .containsExactly("\\/valid\\/regex");
+  }
+
+  @Test
+  void should_ignore_empty_lines_from_whitelist_file_but_continue() throws URISyntaxException {
+    Map<String, Object> config = new HashMap<>();
+    config.put("KROKI_PLANTUML_INCLUDE_WHITELIST", Paths.get(PlantumlServiceTest.class.getResource("/whitelist_empty_lines.txt").toURI()).toString());
+    List<Pattern> patterns = Plantuml.parseIncludeWhitelist(new JsonObject(config));
+    assertThat(patterns)
+      .extracting("pattern")
+      .containsExactly("/path/to/includes", "/other/includes");
+  }
+
+  @Test
+  void should_return_valid_regexp_from_whitelist_file() throws URISyntaxException {
+    Map<String, Object> config = new HashMap<>();
+    config.put("KROKI_PLANTUML_INCLUDE_WHITELIST", Paths.get(PlantumlServiceTest.class.getResource("/whitelist_valid.txt").toURI()).toString());
+    List<Pattern> patterns = Plantuml.parseIncludeWhitelist(new JsonObject(config));
+    assertThat(patterns)
+      .extracting("pattern")
+      .containsExactly("https:\\/\\/kroki\\.io\\/includes");
+  }
+
+  @Test
+  void should_ignore_invalid_number_in_whitelist_environment_variable() {
+    Map<String, Object> config = new HashMap<>();
+    config.put("KROKI_PLANTUML_INCLUDE_WHITELIST_00", "/path/to/includes");
+    List<Pattern> patterns = Plantuml.parseIncludeWhitelist(new JsonObject(config));
+    assertThat(patterns).isEmpty();
+  }
+
+  @Test
+  void should_add_valid_regex_from_whitelist_environment_variable() {
+    Map<String, Object> config = new HashMap<>();
+    config.put("KROKI_PLANTUML_INCLUDE_WHITELIST_0", "/path/to/includes");
+    List<Pattern> patterns = Plantuml.parseIncludeWhitelist(new JsonObject(config));
+    assertThat(patterns)
+      .extracting("pattern")
+      .containsExactly("/path/to/includes");
+  }
+
+  @Test
+  void should_stop_when_index_missing_in_whitelist_environment_variables() {
+    Map<String, Object> config = new HashMap<>();
+    config.put("KROKI_PLANTUML_INCLUDE_WHITELIST_0", "/path/to/includes");
+    // index 1 is missing
+    config.put("KROKI_PLANTUML_INCLUDE_WHITELIST_2", "/another/path");
+    List<Pattern> patterns = Plantuml.parseIncludeWhitelist(new JsonObject(config));
+    assertThat(patterns)
+      .extracting("pattern")
+      .containsExactly("/path/to/includes");
+  }
+
+  @Test
+  void should_iterate_on_whitelist_environment_variables() {
+    Map<String, Object> config = new HashMap<>();
+    config.put("KROKI_PLANTUML_INCLUDE_WHITELIST_0", "/path1");
+    config.put("KROKI_PLANTUML_INCLUDE_WHITELIST_1", "/path2");
+    config.put("KROKI_PLANTUML_INCLUDE_WHITELIST_2", "/path3");
+    List<Pattern> patterns = Plantuml.parseIncludeWhitelist(new JsonObject(config));
+    assertThat(patterns)
+      .extracting("pattern")
+      .containsExactly("/path1", "/path2", "/path3");
+  }
+
+  @Test
+  void should_ignore_invalid_regex_on_whitelist_environment_variables() {
+    Map<String, Object> config = new HashMap<>();
+    config.put("KROKI_PLANTUML_INCLUDE_WHITELIST_0", "/path1");
+    config.put("KROKI_PLANTUML_INCLUDE_WHITELIST_1", "this\\is\\an\\invalid\\regular\\/expression");
+    config.put("KROKI_PLANTUML_INCLUDE_WHITELIST_2", "/path3");
+    List<Pattern> patterns = Plantuml.parseIncludeWhitelist(new JsonObject(config));
+    assertThat(patterns)
+      .extracting("pattern")
+      .containsExactly("/path1", "/path3");
+  }
+
+  @Test
+  void should_trim_regex_on_whitelist_environment_variables() {
+    Map<String, Object> config = new HashMap<>();
+    config.put("KROKI_PLANTUML_INCLUDE_WHITELIST_0", "/path1  ");
+    config.put("KROKI_PLANTUML_INCLUDE_WHITELIST_1", "  /path2 ");
+    config.put("KROKI_PLANTUML_INCLUDE_WHITELIST_2", "\t/path3\n");
+    List<Pattern> patterns = Plantuml.parseIncludeWhitelist(new JsonObject(config));
+    assertThat(patterns)
+      .extracting("pattern")
+      .containsExactly("/path1", "/path2", "/path3");
   }
 }

--- a/server/src/test/resources/whitelist_empty_lines.txt
+++ b/server/src/test/resources/whitelist_empty_lines.txt
@@ -1,0 +1,4 @@
+/path/to/includes
+   
+/other/includes
+	

--- a/server/src/test/resources/whitelist_invalid.txt
+++ b/server/src/test/resources/whitelist_invalid.txt
@@ -1,0 +1,1 @@
+this\is\an\invalid\regular\/expression

--- a/server/src/test/resources/whitelist_mixed.txt
+++ b/server/src/test/resources/whitelist_mixed.txt
@@ -1,0 +1,2 @@
+this\\is\an\invalid\regular\/expression
+\/valid\/regex

--- a/server/src/test/resources/whitelist_valid.txt
+++ b/server/src/test/resources/whitelist_valid.txt
@@ -1,0 +1,1 @@
+https:\/\/kroki\.io\/includes


### PR DESCRIPTION
We generate images as part of our build chain and so we trust the URLs and other libraries that we want to use as includes. The current includes blocking is heavy handed. This should allow import path includes as well as enabling a whitelist of regexes for anyone who wants to allow including only a subset of URLs that they actually trust.

Note: I would advise repeating my analysis of PlantUML's `ImportedFiles` to verify that for regular file imports it only permits the inclusion of files that are actually on the include path (my analysis showed that it is a bit too strict as you cannot have `!include foo/bar.puml` because the `getSystemFolder()` will then return `$DIR_FROM_SEARCH_PATH/foo` which is not explicitly one of the files on the search path... but that seems sufficiently strict from my PoV to allow any paths that do not contain `..` style navigation and are not URLs