### PR TITLE
Bumb svgbob from 0.4.2 to 0.5.3

### DIFF
--- a/server/ops/docker/build-static-svgbob
+++ b/server/ops/docker/build-static-svgbob
@@ -1,4 +1,4 @@
 # build static executable binary
 FROM ekidd/rust-musl-builder:stable
 
-RUN cargo install --version 0.4.2 svgbob_cli
+RUN cargo install --version 0.5.3 svgbob_cli


### PR DESCRIPTION
Svgbob 0.5.0 supports shape tagging and styling