### PR TITLE
resolves #386 install CJK font

### DIFF
--- a/server/ops/docker/jdk11-alpine/Dockerfile
+++ b/server/ops/docker/jdk11-alpine/Dockerfile
@@ -21,10 +21,7 @@ RUN apk add --update --no-cache \
            giflib-dev \
            graphviz \
            ttf-freefont \
-# Chinese font (available only in edge/testing)
- && apk add --update --no-cache \
-            --repository https://dl-cdn.alpinelinux.org/alpine/edge/testing/ \
-           wqy-zenhei
+           font-noto-cjk
 
 COPY --chown=kroki:kroki ops/docker/logback.xml /etc/kroki/logback.xml
 


### PR DESCRIPTION
With this change, CJK characters are now correctly rendered when converting to PNG:

![out](https://user-images.githubusercontent.com/333276/106567111-8ab73f00-6531-11eb-9cf7-d77d353acd78.png)

For reference, here's the result using http://www.plantuml.com/

![plantuml](https://user-images.githubusercontent.com/333276/106567324-f13c5d00-6531-11eb-82db-618d632fbf7c.png)

The package [`font-noto-cjk`](https://pkgs.alpinelinux.org/package/edge/community/x86_64/font-noto-cjk) (and all its dependencies) is quite large, approximately 200MB.
Here's the Docker image size before (0.10.0) and after (latest):

```
yuzutech/kroki     0.10.0     434MB
yuzutech/kroki     latest     650MB
```

resolves #386

