### PR TITLE
KROKI_LISTEN option to start listening on an address

### DIFF
--- a/docs/modules/setup/pages/configuration.adoc
+++ b/docs/modules/setup/pages/configuration.adoc
@@ -1,17 +1,46 @@
 = Configuration
+:url-k8s-environment-variables: https://kubernetes.io/docs/concepts/services-networking/service/#environment-variables
 
 Kroki can be configured using environment variables or Java system properties.
 
-== Port
+== Server Listening
 
-By default, Kroki will start a web server on port `8000`.
-You can change the port using `KROKI_PORT`:
-
-[source,java-cli]
-KROKI_PORT=1234 java -jar kroki-server.jar
+By default, Kroki will bind to all network interfaces (`0.0.0.0`) on port `8000`.
+You can change on which host and port the server will listen for incoming requests using `KROKI_LISTEN`:
 
 [source,java-cli]
-java -DKROKI_PORT=1234 -jar kroki-server.jar
+KROKI_LISTEN=127.0.0.1:1234 java -jar kroki-server.jar
+
+[source,java-cli]
+java -DKROKI_LISTEN=127.0.0.1:1234 -jar kroki-server.jar
+
+With the above configuration, the server will bind to `127.0.0.1` (i.e., loopback address) on port 1234.
+
+[NOTE]
+====
+If the port is unspecified, the server will listen on port `8000`.
+If the host is unspecified, the server will use `[::]` (i.e., bind to all network interfaces and accept connections from both IPv6 or IPv4 hosts)
+
+`KROKI_LISTEN` also accepts IPv6 enclosed within square brackets (`[` and `]`),
+for instance: `KROKI_LISTEN=2001:db8:1f70::999:de8:7648:6e8]:1234`.
+====
+
+
+[IMPORTANT]
+====
+*`KROKI_PORT` is deprecated and will be removed in the future.*
+
+We are deprecating this option because it conflicts with Kubernetes and Docker built-in environnement variables.
+For reference, {url-k8s-environment-variables}[Kubernetes will automatically set the environment variable] `{SERVICE_NAME}_PORT` to `tcp://1.2.3.4:8000`.
+As you might have guessed, if you use `KROKI` as a service name, there's going to be a problem!
+In fact, Kroki expects the value of `KROKI_PORT` to be an integer value. +
+To workaround this issue, until `KROKI_PORT` is removed, you can explicitly define the environment variable `KROKI_PORT=8000`.
+
+If you were using a custom port (for instance, `KROKI_PORT=1234`), you can replace it by `KROKI_LISTEN=0.0.0.0:1234` (which is strictly equivalent). +
+If you want to bind to IPv4 and IPv6, you can use `KROKI_LISTEN=:1234` or the longer form `KROKI_LISTEN=[::]:1234`.
+
+If you want to learn about this deprecation, you can read: https://github.com/yuzutech/kroki/issues/576
+====
 
 == Safe Mode
 

--- a/docs/modules/setup/pages/configuration.adoc
+++ b/docs/modules/setup/pages/configuration.adoc
@@ -22,7 +22,7 @@ If the port is unspecified, the server will listen on port `8000`.
 If the host is unspecified, the server will use `[::]` (i.e., bind to all network interfaces and accept connections from both IPv6 or IPv4 hosts)
 
 `KROKI_LISTEN` also accepts IPv6 enclosed within square brackets (`[` and `]`),
-for instance: `KROKI_LISTEN=2001:db8:1f70::999:de8:7648:6e8]:1234`.
+for instance: `KROKI_LISTEN=[2001:db8:1f70::999:de8:7648:6e8]:1234`.
 ====
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,6 +5,9 @@
   <artifactId>kroki</artifactId>
   <packaging>pom</packaging>
   <version>0.10.0</version>
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
   <modules>
     <module>server</module>
     <module>umlet</module>

--- a/server/ops/docker/jdk11-alpine/Dockerfile
+++ b/server/ops/docker/jdk11-alpine/Dockerfile
@@ -17,6 +17,7 @@ RUN apk add --update --no-cache \
 
 COPY ops/docker/logback.xml /etc/logback.xml
 
+ENV KROKI_CONTAINER_SUPPORT=""
 ENV KROKI_SAFE_MODE=secure
 ENV KROKI_SVGBOB_BIN_PATH=/rust/bin/svgbob
 ENV KROKI_ERD_BIN_PATH=/haskell/bin/erd

--- a/server/src/main/java/io/kroki/server/Server.java
+++ b/server/src/main/java/io/kroki/server/Server.java
@@ -2,6 +2,7 @@ package io.kroki.server;
 
 import io.kroki.server.action.Commander;
 import io.kroki.server.error.ErrorHandler;
+import io.kroki.server.log.Logging;
 import io.kroki.server.service.Blockdiag;
 import io.kroki.server.service.Bpmn;
 import io.kroki.server.service.Bytefield;
@@ -205,6 +206,11 @@ public class Server extends AbstractVerticle {
       }
     } else {
       port = config.getInteger("KROKI_PORT", DEFAULT_PORT);
+      if (port != DEFAULT_PORT) {
+        Logging.deprecationLogger.warn("KROKI_PORT is deprecated and will be removed in a future version, please use KROKI_LISTEN=0.0.0.0:{} - documentation: {}",
+          port,
+          "https://docs.kroki.io/kroki/setup/configuration/");
+      }
     }
     return port;
   }

--- a/server/src/main/java/io/kroki/server/log/Logging.java
+++ b/server/src/main/java/io/kroki/server/log/Logging.java
@@ -6,10 +6,12 @@ import io.vertx.core.http.HttpServerRequest;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.client.HttpResponse;
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 
 public class Logging {
 
+  public static final Logger deprecationLogger = LoggerFactory.getLogger("io.kroki.server.deprecation");
   private final Logger logger;
 
   public Logging(Logger logger) {
@@ -114,4 +116,6 @@ public class Logging {
       MDC.remove("error_message");
     }
   }
+
+
 }

--- a/server/src/test/java/io/kroki/server/ServerConfigTest.java
+++ b/server/src/test/java/io/kroki/server/ServerConfigTest.java
@@ -1,0 +1,116 @@
+package io.kroki.server;
+
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.net.SocketAddress;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ServerConfigTest {
+
+  @Test
+  void throw_exception_when_non_ipv6_listen_address_contains_more_than_one_colon() {
+    assertThatThrownBy(() ->  Server.getListenAddress(new JsonObject().put("KROKI_LISTEN", "localhost:1234:5678")))
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessageStartingWith("KROKI_LISTEN is not a valid listen address 'localhost:1234:5678', format must be: 'host:5678', ':5678', '1.2.3.4:5678', '[2041:0:140f::875b:131b]:5678' or '[2041:0:140f::875b:131b]'");
+  }
+
+  @Test
+  void throw_exception_when_listen_address_contains_host_as_port() {
+    assertThatThrownBy(() ->  Server.getListenAddress(new JsonObject().put("KROKI_LISTEN", ":localhost")))
+      .isInstanceOf(NumberFormatException.class)
+      .hasMessageStartingWith("For input string: \"localhost\"");
+  }
+
+  @Test
+  void throw_exception_when_listen_address_contains_ipv4_as_port() {
+    assertThatThrownBy(() ->  Server.getListenAddress(new JsonObject().put("KROKI_LISTEN", ":192.168.0.1")))
+      .isInstanceOf(NumberFormatException.class)
+      .hasMessageStartingWith("For input string: \"192.168.0.1\"");
+  }
+
+  @Test
+  void throw_exception_when_listen_address_contains_an_empty_port() {
+    assertThatThrownBy(() ->  Server.getListenAddress(new JsonObject().put("KROKI_LISTEN", "localhost:")))
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessageStartingWith("For input string: \"\"");
+  }
+
+  @Test
+  void return_socket_address_when_listen_address_ipv6() {
+    SocketAddress listenAddress = Server.getListenAddress(new JsonObject().put("KROKI_LISTEN", "[2001:db8:1f70::999:de8:7648:6e8]"));
+    assertThat(listenAddress.host()).isEqualTo("[2001:db8:1f70::999:de8:7648:6e8]");
+    assertThat(listenAddress.port()).isEqualTo(8000);
+  }
+
+  @Test
+  void return_socket_address_when_listen_address_ipv4() {
+    SocketAddress listenAddress = Server.getListenAddress(new JsonObject().put("KROKI_LISTEN", "192.168.0.1"));
+    assertThat(listenAddress.host()).isEqualTo("192.168.0.1");
+    assertThat(listenAddress.port()).isEqualTo(8000);
+  }
+
+  @Test
+  void return_socket_address_when_listen_address_host() {
+    SocketAddress listenAddress = Server.getListenAddress(new JsonObject().put("KROKI_LISTEN", "kroki.io"));
+    assertThat(listenAddress.host()).isEqualTo("kroki.io");
+    assertThat(listenAddress.port()).isEqualTo(8000);
+  }
+
+  @Test
+  void return_socket_address_when_listen_address_default_ip() {
+    SocketAddress listenAddress = Server.getListenAddress(new JsonObject().put("KROKI_LISTEN", "0.0.0.0"));
+    assertThat(listenAddress.host()).isEqualTo("0.0.0.0");
+    assertThat(listenAddress.port()).isEqualTo(8000);
+  }
+
+  @Test
+  void return_socket_address_when_listen_address_any_ip() {
+    SocketAddress listenAddress = Server.getListenAddress(new JsonObject().put("KROKI_LISTEN", "[::]"));
+    assertThat(listenAddress.host()).isEqualTo("[::]");
+    assertThat(listenAddress.port()).isEqualTo(8000);
+  }
+
+  @Test
+  void return_socket_address_when_listen_address_contains_ipv6_port() {
+    SocketAddress listenAddress = Server.getListenAddress(new JsonObject().put("KROKI_LISTEN", "[2001:db8::8a2e:370:7334]:1234"));
+    assertThat(listenAddress.host()).isEqualTo("[2001:db8::8a2e:370:7334]");
+    assertThat(listenAddress.port()).isEqualTo(1234);
+  }
+
+  @Test
+  void return_socket_address_when_listen_address_localhost_port() {
+    SocketAddress listenAddress = Server.getListenAddress(new JsonObject().put("KROKI_LISTEN", "localhost:1234"));
+    assertThat(listenAddress.host()).isEqualTo("localhost");
+    assertThat(listenAddress.port()).isEqualTo(1234);
+  }
+
+  @Test
+  void return_socket_address_when_listen_address_domain_port() {
+    SocketAddress listenAddress = Server.getListenAddress(new JsonObject().put("KROKI_LISTEN", "kroki.io:1234"));
+    assertThat(listenAddress.host()).isEqualTo("kroki.io");
+    assertThat(listenAddress.port()).isEqualTo(1234);
+  }
+
+  @Test
+  void return_socket_address_when_listen_address_default_ip_port() {
+    SocketAddress listenAddress = Server.getListenAddress(new JsonObject().put("KROKI_LISTEN", "0.0.0.0:2345"));
+    assertThat(listenAddress.host()).isEqualTo("0.0.0.0");
+    assertThat(listenAddress.port()).isEqualTo(2345);
+  }
+
+  @Test
+  void return_socket_address_when_listen_address_local_ip_port() {
+    SocketAddress listenAddress = Server.getListenAddress(new JsonObject().put("KROKI_LISTEN", "127.0.0.1:2345"));
+    assertThat(listenAddress.host()).isEqualTo("127.0.0.1");
+    assertThat(listenAddress.port()).isEqualTo(2345);
+  }
+
+  @Test
+  void return_socket_address_when_listen_address_address_port() {
+    SocketAddress listenAddress = Server.getListenAddress(new JsonObject().put("KROKI_LISTEN", ":3456"));
+    assertThat(listenAddress.host()).isEqualTo("[::]"); // default host to listen on both IPv4 and IPv6
+    assertThat(listenAddress.port()).isEqualTo(3456);
+  }
+}

--- a/server/src/test/java/io/kroki/server/ServerListenTest.java
+++ b/server/src/test/java/io/kroki/server/ServerListenTest.java
@@ -1,0 +1,128 @@
+package io.kroki.server;
+
+import io.vertx.core.DeploymentOptions;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.client.WebClient;
+import io.vertx.ext.web.codec.BodyCodec;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.DatagramSocket;
+import java.net.ServerSocket;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(VertxExtension.class)
+class ServerListenTest {
+
+  private static final Logger logger = LoggerFactory.getLogger(ServerListenTest.class);
+
+  @Test
+  void http_server_start_default_check_response(Vertx vertx, VertxTestContext testContext) {
+    if (available(8000)) {
+      vertx.deployVerticle(new Server(), new DeploymentOptions(), testContext.succeeding(id -> checkServerListening(8000, testContext, vertx)));
+    } else {
+      logger.warn("Port 8000 is not available, skipping test");
+    }
+  }
+
+  @Test
+  void http_server_start_default_container_check_response(Vertx vertx, VertxTestContext testContext) {
+    if (available(8000)) {
+      DeploymentOptions options = new DeploymentOptions().setConfig(new JsonObject().put("KROKI_CONTAINER_SUPPORT", ""));
+      vertx.deployVerticle(new Server(), options, testContext.succeeding(id -> checkServerListening(8000, testContext, vertx)));
+    } else {
+      logger.warn("Port 8000 is not available, skipping test");
+    }
+  }
+
+  @Test
+  void http_server_start_k8s_container_check_response(Vertx vertx, VertxTestContext testContext) {
+    if (available(8000)) {
+      DeploymentOptions options = new DeploymentOptions()
+        .setConfig(new JsonObject()
+          .put("KROKI_CONTAINER_SUPPORT", "")
+          .put("KROKI_PORT", "tcp://1.2.3.4:8000")
+        );
+      vertx.deployVerticle(new Server(), options, testContext.succeeding(id -> checkServerListening(8000, testContext, vertx)));
+    } else {
+      logger.warn("Port 8000 is not available, skipping test");
+    }
+  }
+
+  @Test
+  void http_server_start_listen_local_ip_check_response(Vertx vertx, VertxTestContext testContext) throws IOException {
+    int port = getAvailablePort();
+    DeploymentOptions options = new DeploymentOptions().setConfig(new JsonObject().put("KROKI_LISTEN", "127.0.0.1:" + port));
+    vertx.deployVerticle(new Server(), options, testContext.succeeding(id -> checkServerListening(port, testContext, vertx)));
+  }
+
+  @Test
+  void http_server_start_listen_any_check_response(Vertx vertx, VertxTestContext testContext) throws IOException {
+    int port = getAvailablePort();
+    DeploymentOptions options = new DeploymentOptions().setConfig(new JsonObject().put("KROKI_LISTEN", "[::]:" + port));
+    vertx.deployVerticle(new Server(), options, testContext.succeeding(id -> checkServerListening(port, testContext, vertx)));
+  }
+
+  @Test
+  void http_server_start_listen_port_check_response(Vertx vertx, VertxTestContext testContext) throws IOException {
+    int port = getAvailablePort();
+    DeploymentOptions options = new DeploymentOptions().setConfig(new JsonObject().put("KROKI_LISTEN", ":" + port));
+    vertx.deployVerticle(new Server(), options, testContext.succeeding(id -> checkServerListening(port, testContext, vertx)));
+  }
+
+  @Test
+  void http_server_check_response(Vertx vertx, VertxTestContext testContext) throws IOException {
+    int port = getAvailablePort();
+    DeploymentOptions options = new DeploymentOptions().setConfig(new JsonObject().put("KROKI_PORT", port));
+    vertx.deployVerticle(new Server(), options, testContext.succeeding(id -> checkServerListening(port, testContext, vertx)));
+  }
+
+  private void checkServerListening(int port, VertxTestContext testContext, Vertx vertx) {
+    WebClient client = WebClient.create(vertx);
+    client.get(port, "localhost", "/")
+      .as(BodyCodec.string())
+      .send(testContext.succeeding(response -> testContext.verify(() -> {
+        assertThat(response.body()).contains("https://kroki.io");
+        testContext.completeNow();
+      })));
+  }
+
+  private int getAvailablePort() throws IOException {
+    ServerSocket socket = new ServerSocket(0);
+    int port = socket.getLocalPort();
+    socket.close();
+    return port;
+  }
+
+  public static boolean available(int port) {
+    ServerSocket ss = null;
+    DatagramSocket ds = null;
+    try {
+      ss = new ServerSocket(port);
+      ss.setReuseAddress(true);
+      ds = new DatagramSocket(port);
+      ds.setReuseAddress(true);
+      return true;
+    } catch (IOException ignored) {
+    } finally {
+      if (ds != null) {
+        ds.close();
+      }
+      if (ss != null) {
+        try {
+          ss.close();
+        } catch (IOException e) {
+          /* should not be thrown */
+        }
+      }
+    }
+    return false;
+  }
+}


### PR DESCRIPTION
- KROKI_LISTEN has higher precedence than KROKI_PORT
- Support `tcp://ip:port` value on KROKI_PORT (this value can be automatically set by the container runtime: k8s, Docker...)
- Set KROKI_CONTAINER_SUPPORT environment variable on the Docker image to indicate that we are running in a container

resolves #576 