### PR TITLE
Load application code before the worker processes are forked

### DIFF
--- a/blockdiag/Dockerfile
+++ b/blockdiag/Dockerfile
@@ -18,4 +18,4 @@ COPY src .
 
 EXPOSE 8001
 
-CMD ["gunicorn", "--bind", "0.0.0.0:8001", "wsgi"]
+CMD ["gunicorn", "--preload", "--bind", "0.0.0.0:8001", "wsgi"]


### PR DESCRIPTION
Sometimes `gunicorn` fails to start, I believe that the `--preload` option can improve the situation: https://docs.gunicorn.org/en/stable/settings.html#server-mechanics