### PR TITLE
Use fixed versions to improve build reliability

### DIFF
--- a/bpmn/Dockerfile
+++ b/bpmn/Dockerfile
@@ -6,12 +6,14 @@ FROM node:12.19.0-alpine3.11 as builder
 # [ 'nobody', 0 ]
 RUN npm config set unsafe-perm true
 
-RUN npm install -g pkg pkg-fetch
+# Workaround: https://github.com/vercel/pkg-fetch/issues/165
+# use pkg-fetch 2.6.0 because alpine binaries are not available on pkg-fetch 3.x
+RUN npm install -g pkg@4.5.1 pkg-fetch@2.6.0
 
 ENV NODE node10
 ENV PLATFORM alpine
 ENV ARCH x64
-RUN /usr/local/bin/pkg-fetch ${NODE} ${PLATFORM} ${ARCH}
+RUN /usr/local/bin/pkg-fetch -n ${NODE} -p ${PLATFORM} -a ${ARCH}
 
 WORKDIR /app
 

--- a/bytefield/ops/docker/alpine/Dockerfile
+++ b/bytefield/ops/docker/alpine/Dockerfile
@@ -5,11 +5,14 @@ FROM node:12.19.0-alpine
 # [ 'nobody', 0 ]
 RUN npm config set unsafe-perm true
 
-RUN npm install -g pkg pkg-fetch
+# Workaround: https://github.com/vercel/pkg-fetch/issues/165
+# use pkg-fetch 2.6.0 because alpine binaries are not available on pkg-fetch 3.x
+RUN npm install -g pkg@4.5.1 pkg-fetch@2.6.0
+
 ENV NODE node10
 ENV PLATFORM alpine
 ENV ARCH x64
-RUN /usr/local/bin/pkg-fetch ${NODE} ${PLATFORM} ${ARCH}
+RUN /usr/local/bin/pkg-fetch -n ${NODE} -p ${PLATFORM} -a ${ARCH}
 
 COPY index.js package.json package-lock.json /app/
 WORKDIR /app

--- a/excalidraw/Dockerfile
+++ b/excalidraw/Dockerfile
@@ -6,12 +6,14 @@ FROM node:12.22.1-alpine3.11 as builder
 # [ 'nobody', 0 ]
 RUN npm config set unsafe-perm true
 
-RUN npm install -g pkg pkg-fetch
+# Workaround: https://github.com/vercel/pkg-fetch/issues/165
+# use pkg-fetch 2.6.0 because alpine binaries are not available on pkg-fetch 3.x
+RUN npm install -g pkg@4.5.1 pkg-fetch@2.6.0
 
 ENV NODE node10
 ENV PLATFORM alpine
 ENV ARCH x64
-RUN /usr/local/bin/pkg-fetch ${NODE} ${PLATFORM} ${ARCH}
+RUN /usr/local/bin/pkg-fetch -n ${NODE} -p ${PLATFORM} -a ${ARCH}
 
 WORKDIR /app
 

--- a/mermaid/Dockerfile
+++ b/mermaid/Dockerfile
@@ -6,12 +6,14 @@ FROM node:12.19.0-alpine3.11 as builder
 # [ 'nobody', 0 ]
 RUN npm config set unsafe-perm true
 
-RUN npm install -g pkg pkg-fetch
+# Workaround: https://github.com/vercel/pkg-fetch/issues/165
+# use pkg-fetch 2.6.0 because alpine binaries are not available on pkg-fetch 3.x
+RUN npm install -g pkg@4.5.1 pkg-fetch@2.6.0
 
 ENV NODE node10
 ENV PLATFORM alpine
 ENV ARCH x64
-RUN /usr/local/bin/pkg-fetch ${NODE} ${PLATFORM} ${ARCH}
+RUN /usr/local/bin/pkg-fetch -n ${NODE} -p ${PLATFORM} -a ${ARCH}
 
 WORKDIR /app
 

--- a/nomnoml/ops/docker/alpine/Dockerfile
+++ b/nomnoml/ops/docker/alpine/Dockerfile
@@ -5,11 +5,14 @@ FROM node:12.19.0-alpine3.11
 # [ 'nobody', 0 ]
 RUN npm config set unsafe-perm true
 
-RUN npm install -g pkg pkg-fetch
+# Workaround: https://github.com/vercel/pkg-fetch/issues/165
+# use pkg-fetch 2.6.0 because alpine binaries are not available on pkg-fetch 3.x
+RUN npm install -g pkg@4.5.1 pkg-fetch@2.6.0
+
 ENV NODE node10
 ENV PLATFORM alpine
 ENV ARCH x64
-RUN /usr/local/bin/pkg-fetch ${NODE} ${PLATFORM} ${ARCH}
+RUN /usr/local/bin/pkg-fetch -n ${NODE} -p ${PLATFORM} -a ${ARCH}
 
 COPY index.js package.json package-lock.json /app/
 WORKDIR /app

--- a/vega/ops/docker/alpine/Dockerfile
+++ b/vega/ops/docker/alpine/Dockerfile
@@ -15,11 +15,14 @@ RUN apk add --no-cache \
         pango-dev \
         giflib-dev
 
-RUN npm install -g pkg pkg-fetch
+# Workaround: https://github.com/vercel/pkg-fetch/issues/165
+# use pkg-fetch 2.6.0 because alpine binaries are not available on pkg-fetch 3.x
+RUN npm install -g pkg@4.5.1 pkg-fetch@2.6.0
+
 ENV NODE node10
 ENV PLATFORM alpine
 ENV ARCH x64
-RUN /usr/local/bin/pkg-fetch ${NODE} ${PLATFORM} ${ARCH}
+RUN /usr/local/bin/pkg-fetch -n ${NODE} -p ${PLATFORM} -a ${ARCH}
 
 COPY index.js package.json package-lock.json /app/
 WORKDIR /app

--- a/wavedrom/ops/docker/alpine/Dockerfile
+++ b/wavedrom/ops/docker/alpine/Dockerfile
@@ -5,11 +5,14 @@ FROM node:12.22.1-alpine3.11
 # [ 'nobody', 0 ]
 RUN npm config set unsafe-perm true
 
-RUN npm install -g pkg pkg-fetch
+# Workaround: https://github.com/vercel/pkg-fetch/issues/165
+# use pkg-fetch 2.6.0 because alpine binaries are not available on pkg-fetch 3.x
+RUN npm install -g pkg@4.5.1 pkg-fetch@2.6.0
+
 ENV NODE node10
 ENV PLATFORM alpine
 ENV ARCH x64
-RUN /usr/local/bin/pkg-fetch ${NODE} ${PLATFORM} ${ARCH}
+RUN /usr/local/bin/pkg-fetch -n ${NODE} -p ${PLATFORM} -a ${ARCH}
 
 COPY index.js package.json package-lock.json /app/
 WORKDIR /app


### PR DESCRIPTION
Also explicit CLI option on `pkg-fetch`:

- `-n`: Node version (node10)
- `-p`: Platform (alpine)
- `-a`: Architecture (x64)