### PR TITLE
tell GCC to build a static binary for pikchr

### DIFF
--- a/server/ops/docker/build-static-pikchr
+++ b/server/ops/docker/build-static-pikchr
@@ -7,4 +7,4 @@ WORKDIR build
 
 RUN wget -q https://pikchr.org/home/raw/7269f78c4a3aa2809bd8c278e522c4eac5568ad0fd6ed0a3f807f4a2f6367ef0 -O pikchr.c
 
-RUN gcc -O0 -g -Wall -Wextra -DPIKCHR_SHELL pikchr.c -o pikchr -lm
+RUN gcc -O0 -g -static -Wall -Wextra -DPIKCHR_SHELL pikchr.c -o pikchr -lm


### PR DESCRIPTION
the previous version of this dockerfile didn't build a static binary, but that issue was masked because the image used to build the binary, and the image where the binary ran, both have the required dynamic libraries.

This commit fixes the issue, by passing GCC the `-static` flag to build a static binary.