### PR TITLE
workaround for issue with CORS and Origin: null in vertx-web

### DIFF
--- a/server/src/main/java/io/kroki/server/Server.java
+++ b/server/src/main/java/io/kroki/server/Server.java
@@ -89,7 +89,10 @@ public class Server extends AbstractVerticle {
     allowedMethods.add(HttpMethod.GET);
     allowedMethods.add(HttpMethod.POST);
     allowedMethods.add(HttpMethod.OPTIONS);
-    router.route().handler(CorsHandler.create("*")
+    // REMIND: In order to accept requests with `Origin: null` header, we are using the value ".*" instead of "*".
+    // This can be reverted back to "*" once https://github.com/vert-x3/vertx-web/issues/1933 is fixed.
+    // Reference: https://github.com/yuzutech/kroki/pull/711
+    router.route().handler(CorsHandler.create(".*")
       .allowedHeaders(allowedHeaders)
       .allowedMethods(allowedMethods));
 

--- a/server/src/test/java/io/kroki/server/ServerTest.java
+++ b/server/src/test/java/io/kroki/server/ServerTest.java
@@ -51,6 +51,30 @@ class ServerTest {
   }
 
   @Test
+  void http_server_check_cors_handling_regular_origin(Vertx vertx, VertxTestContext testContext) {
+    WebClient client = WebClient.create(vertx);
+    client.get(port, "localhost", "/")
+      .putHeader("Origin", "http://localhost")
+      .as(BodyCodec.string())
+      .send(testContext.succeeding(response -> testContext.verify(() -> {
+        assertThat(response.statusCode()).isEqualTo(200);
+        testContext.completeNow();
+      })));
+  }
+
+  @Test
+  void http_server_check_cors_handling_null_origin(Vertx vertx, VertxTestContext testContext) {
+    WebClient client = WebClient.create(vertx);
+    client.get(port, "localhost", "/")
+      .putHeader("Origin", "null")
+      .as(BodyCodec.string())
+      .send(testContext.succeeding(response -> testContext.verify(() -> {
+        assertThat(response.statusCode()).isEqualTo(200);
+        testContext.completeNow();
+      })));
+  }
+
+  @Test
   void http_server_long_uri_414(Vertx vertx, VertxTestContext testContext) {
     WebClient client = WebClient.create(vertx);
     client.get(port, "localhost", "/" + randomAlphaString(5000))


### PR DESCRIPTION
The CORS handling mechanism of vertx-web should allow an HTTP header
with `Origin: null`, but currently it doesn't, and it causes requests to Kroki 
with that header to fail; see https://github.com/vert-x3/vertx-web/issues/1933
for the details.

This interferes with using Kroki in some scenarios, for example, using it
from a browser (javascript) in a webpage that is served from a `file://` URL.

While that bug is fixed, this commit adds a workaround that enables
Kroki to handle that header value properly.

The workaround just defines a regexp that allows any value in that
header; vertx-web just matches the value using that regexp, and if it
matches the request continues its processing as normal.