### PR TITLE
Update companion images description on Docker Hub

### DIFF
--- a/.github/workflows/dockerhub-description.yml
+++ b/.github/workflows/dockerhub-description.yml
@@ -53,5 +53,5 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
           repository: yuzutech/kroki-blockdiag
-          short-description: Companion image for blockdiag to use with kroki server
+          short-description: Companion server for Kroki that provides BlockDiag, SeqDiag, ActDiag, NwDiag, PacketDiag and RackDiag
           readme-filepath: ./DOCKERHUB-COMPANION.md

--- a/.github/workflows/dockerhub-description.yml
+++ b/.github/workflows/dockerhub-description.yml
@@ -26,7 +26,7 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
           repository: yuzutech/kroki-bpmn
-          short-description: Companion image for BPMN to use with kroki server
+          short-description: Companion server for Kroki that provides BPMN
           readme-filepath: ./DOCKERHUB-COMPANION.md
 
       - name: Docker Hub Description - excalidraw
@@ -35,7 +35,7 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
           repository: yuzutech/kroki-excalidraw
-          short-description: Companion image for excalidraw to use with kroki server
+          short-description: Companion server for Kroki that provides Excalidraw
           readme-filepath: ./DOCKERHUB-COMPANION.md
 
       - name: Docker Hub Description - mermaid
@@ -44,7 +44,7 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
           repository: yuzutech/kroki-mermaid
-          short-description: Companion image for mermaid to use with kroki server
+          short-description: Companion server for Kroki that provides Mermaid
           readme-filepath: ./DOCKERHUB-COMPANION.md
 
       - name: Docker Hub Description - blockdiag

--- a/.github/workflows/dockerhub-description.yml
+++ b/.github/workflows/dockerhub-description.yml
@@ -19,3 +19,39 @@ jobs:
           repository: yuzutech/kroki
           short-description: ${{ github.event.repository.description }}
           readme-filepath: ./DOCKERHUB.md
+
+      - name: Docker Hub Description - bpmn
+        uses: peter-evans/dockerhub-description@v2.4.2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          repository: yuzutech/kroki-bpmn
+          short-description: Companion image for BPMN to use with kroki server
+          readme-filepath: ./DOCKERHUB-COMPANION.md
+
+      - name: Docker Hub Description - excalidraw
+        uses: peter-evans/dockerhub-description@v2.4.2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          repository: yuzutech/kroki-excalidraw
+          short-description: Companion image for excalidraw to use with kroki server
+          readme-filepath: ./DOCKERHUB-COMPANION.md
+
+      - name: Docker Hub Description - mermaid
+        uses: peter-evans/dockerhub-description@v2.4.2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          repository: yuzutech/kroki-mermaid
+          short-description: Companion image for mermaid to use with kroki server
+          readme-filepath: ./DOCKERHUB-COMPANION.md
+
+      - name: Docker Hub Description - blockdiag
+        uses: peter-evans/dockerhub-description@v2.4.2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          repository: yuzutech/kroki-blockdiag
+          short-description: Companion image for blockdiag to use with kroki server
+          readme-filepath: ./DOCKERHUB-COMPANION.md

--- a/DOCKERHUB-COMPANION.md
+++ b/DOCKERHUB-COMPANION.md
@@ -10,7 +10,7 @@ Use this images with:
 * [Docker-compose](https://docs.kroki.io/kroki/setup/install/#_using_docker_compose)
 * [Kubernetes](https://docs.kroki.io/kroki/setup/install/#_using_kubernetes)
 
-For installation and configuration see [Kroki docs](https://docs.kroki.io/)
+To learn more about Kroki, read the [documentation](https://docs.kroki.io/).
 
 ## Versioning
 

--- a/DOCKERHUB-COMPANION.md
+++ b/DOCKERHUB-COMPANION.md
@@ -1,6 +1,6 @@
 # Kroki Companion Image
 
-Image to use together with this server: [yuzutech/kroki](https://hub.docker.com/r/yuzutech/kroki)
+Provides additional diagram libraries to [yuzutech/kroki](https://hub.docker.com/r/yuzutech/kroki).
 
 GitHub repository: [kroki](https://github.com/yuzutech/kroki)
 

--- a/DOCKERHUB-COMPANION.md
+++ b/DOCKERHUB-COMPANION.md
@@ -1,4 +1,4 @@
-# Kroki Companion Image
+# Kroki Companion Server
 
 Provides additional diagram libraries to [yuzutech/kroki](https://hub.docker.com/r/yuzutech/kroki).
 

--- a/DOCKERHUB-COMPANION.md
+++ b/DOCKERHUB-COMPANION.md
@@ -1,0 +1,21 @@
+# Kroki Companion Image
+
+Image to use together with this server: [yuzutech/kroki](https://hub.docker.com/r/yuzutech/kroki)
+
+GitHub repository: [kroki](https://github.com/yuzutech/kroki)
+
+## Usage
+
+Use this images with:
+* [Docker-compose](https://docs.kroki.io/kroki/setup/install/#_using_docker_compose)
+* [Kubernetes](https://docs.kroki.io/kroki/setup/install/#_using_kubernetes)
+
+For installation and configuration see [Kroki docs](https://docs.kroki.io/)
+
+## Versioning
+
+We use [SemVer](https://semver.org/) for versioning.
+
+## License
+
+This project is licensed under the MIT License.

--- a/DOCKERHUB-COMPANION.md
+++ b/DOCKERHUB-COMPANION.md
@@ -7,7 +7,7 @@ Read the [Kroki installation](https://docs.kroki.io/kroki/setup/install/#_images
 ## Usage
 
 Use this images with:
-* [Docker-compose](https://docs.kroki.io/kroki/setup/install/#_using_docker_compose)
+* [docker-compose](https://docs.kroki.io/kroki/setup/install/#_using_docker_compose)
 * [Kubernetes](https://docs.kroki.io/kroki/setup/install/#_using_kubernetes)
 
 To learn more about Kroki, read the [documentation](https://docs.kroki.io/).

--- a/DOCKERHUB-COMPANION.md
+++ b/DOCKERHUB-COMPANION.md
@@ -2,7 +2,7 @@
 
 Provides additional diagram libraries to [yuzutech/kroki](https://hub.docker.com/r/yuzutech/kroki).
 
-GitHub repository: [kroki](https://github.com/yuzutech/kroki)
+Read the [Kroki installation](https://docs.kroki.io/kroki/setup/install/#_images) to learn how to start Kroki companion containers.
 
 ## Usage
 


### PR DESCRIPTION
As a follow up to the issue https://github.com/yuzutech/kroki/issues/698 and PR https://github.com/yuzutech/kroki/pull/737 for the companion images.

A proposal with one single file to describe the companion image repositories on Docker hub. 
It is differences between the images but I think it is better to have a simple description in docker hub and instead point to to the docs where information about port setting etc is described.
WDYT @Mogztter?
