### PR TITLE
resolves #828 split install page

### DIFF
--- a/docs/modules/setup/nav.adoc
+++ b/docs/modules/setup/nav.adoc
@@ -4,5 +4,7 @@
 ** xref:kroki-cli.adoc[Kroki CLI]
 * xref:install.adoc[Install]
 //** xref:about-docker-podman.adoc[About Docker and Podman]
+** xref:use-docker-or-podman.adoc[Using Docker or Podman]
+** xref:use-kubernetes.adoc[Using Kubernetes]
 ** xref:manual-install.adoc[Manual Install]
 * xref:configuration.adoc[Configuration]

--- a/docs/modules/setup/pages/install.adoc
+++ b/docs/modules/setup/pages/install.adoc
@@ -1,9 +1,11 @@
 = Install Kroki
+// Docker Hub URIs of Kroki container images
 :uri-docker-kroki-image: https://hub.docker.com/r/yuzutech/kroki
 :uri-docker-kroki-blockdiag-image: https://hub.docker.com/r/yuzutech/kroki-blockdiag
 :uri-docker-kroki-mermaid-image: https://hub.docker.com/r/yuzutech/kroki-mermaid
 :uri-docker-kroki-bpmn-image: https://hub.docker.com/r/yuzutech/kroki-bpmn
 :uri-docker-kroki-excalidraw-image: https://hub.docker.com/r/yuzutech/kroki-excalidraw
+// URIs of diagram generation application sites by diagram name
 :uri-blockdiag: http://blockdiag.com/en/blockdiag/index.html
 :uri-seqdiag: http://blockdiag.com/en/seqdiag/index.html
 :uri-actdiag: http://blockdiag.com/en/actdiag/index.html
@@ -13,157 +15,60 @@
 :uri-mermaid: https://mermaidjs.github.io/
 :uri-bpmn: https://bpmn.io/toolkit/bpmn-js/
 :uri-excalidraw: https://excalidraw.com/
-:uri-docker-container-networking: https://docs.docker.com/config/containers/container-networking/
-:uri-podman-container-networking: https://podman.io/getting-started/network
-:uri-k8s-publish-service: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
-:uri-k8s-definition-files: https://raw.githubusercontent.com/yuzutech/kroki/master/docs/modules/setup/examples/k8s
-:uri-localhost-8000: pass:q[\http://localhost:**8000**]
 
-To convert plain text diagrams to images with Kroki,
-you first need to install the gateway server.
-
-[TIP]
-====
-We recommend installing Kroki using containers with either *Docker* or *Podman*, especially if you don't want to manually install diagrams libraries.
-Read more about choosing Docker or Podman at xref:about-docker-podman.adoc[].
-
-However, you can also install each diagrams libraries that you want to use and run the gateway server as a _standalone executable jar_.
-Consult the xref:manual-install.adoc[manual install page] to find out how.
-====
+This section covers installing Kroki locally.
 
 On this page, you'll learn:
 
-* [x] How to run Kroki
-* [x] How to configure Kroki
+//* [x] Why install Kroki locally
+* [x] How to get started
+* [x] The different ways to install Kroki
+* [x] About the Kroki pre-built image containers and the diagrams they provide
 
-== Install the Kroki gateway server
+== Get started
+To get started, use Docker or Podman to start the mandatory kroki container only.
 
-Installing and running the Kroki gateway server by itself gets you started quickly to begin creating diagrams provided by the <<yuzutech-kroki,`yuzutech/kroki`>> image.
+Use either <<Docker or Podman>> as the easiest and fastest method to get started running Kroki locally on a system with Internet access using the pre-built Kroki containers published on Docker Hub.
 
-Assumptions:
+Start the mandatory <<#yuzutech-kroki,`yuzutech/kroki`>> container only to use a large number of diagram libraries immediately including PlantUML, GraphViz and more.
+Depending on your diagram needs, this may be enough.
 
-* [x] {uri-docker-get-started}[Docker] or {uri-podman-get-started}[Podman] is installed on your machine.
+For the lists of diagram libraries pre-installed in each container see the <<kroki-container-images,Kroki container images>> section on this page.
 
-To start the Kroki gateway server, run the command:
+NOTE: All the companion containers are _optional_.
+Only the <<yuzutech-kroki,yuzutech-kroki>> container is mandatory.
 
-Using docker::
+== Docker or Podman
+We recommend installing Kroki using containers with either Docker or Podman, especially if you don't want to manually install diagrams libraries.
 
-[source,docker-cli]
-docker run yuzutech/kroki
+Read more about choosing between Docker or Podman on the xref:about-docker-podman.adoc[] page.
 
-Using podman::
+Find how to install Kroki using Docker or Podman on the xref:use-docker-or-podman.adoc[] page.
 
-[source,podman-cli]
-podman run yuzutech/kroki
+== Kubernetes
+Find how to make a Kubernetes installation on the xref:use-kubernetes.adoc[] page.
 
-[IMPORTANT]
-====
-By default, when you start a container, it does not publish any of its ports to the outside world. +
-To make a port available to services outside of Docker or Podman, you need to use the `--publish` or `-p` flag.
-====
+== Manual installation
+You can also make a customized manual installation that suits your needs.
 
-[discrete]
-=== Published port
+To do this, you will need to manually install the Kroki gateway server as a _standalone executable jar_, install each diagram library that you want to use, then run the gateway server jar file.
 
-To map a container port to a port on your Docker host, you need to use the `--publish` or `-p` flag.
+You are responsible for managing diagram library installations on your system.
 
-Using docker::
-
-[source,docker-cli]
-docker run -p8000:8000 yuzutech/kroki
-
-Using podman::
-
-[source,podman-cli]
-podman run -p8000:8000 yuzutech/kroki
-
-After the above command, the server will be available on your host at: `{uri-localhost-8000}`
-
-[NOTE]
-====
-You can also map a different TCP port on the Docker host.
-For instance, if you want to map your host's TCP port 1234 to port 8000 in the Kroki container, use: `-p1234:8000`.
-
-In this case, the server will be available on your host at: `\http://localhost:1234`
-====
-
-You can read more about {uri-docker-container-networking}[Docker container networking] and {uri-podman-container-networking}[Podman networking] in their documentation.
-
-[discrete]
-=== Detached mode
-
-The previous methods above ran the containers in the foreground, requiring you to press control-c to stop them.
-Starting containers in detached mode runs them in the background, requiring you to use the Docker/Podman `stop` or `kill` command to stop them.
-
-Finally, to start a container in detached mode, you use `-d` option:
-
-Using docker::
-
-[source,docker-cli]
-docker run -p8000:8000 -d yuzutech/kroki
-
-Using podman::
-
-[source,podman-cli]
-podman run -p8000:8000 -d yuzutech/kroki
-
-After the above command, the server will be available on your host at: `{uri-localhost-8000}`
-
-== Run multiple Kroki containers together
-
-Running multiple containers allows you to use all the diagram features of Kroki in your environment provided by the <<images>>.
-The gateway server container provided by the image <<yuzutech-kroki,`yuzutech/kroki`>> image is the minimum requirement.
-
-[discrete]
-=== Example of running them all together
-
-Here's an example where we start all the Kroki containers together as a group (or pod) in detached mode.
-
-The same Kroki `docker-compose.yml` configuration file below is used by all examples of running the different Kroki containers together.
-
-.docker-compose.yml
-[source,yml]
-----
-include::example$kroki-docker-compose.yml[]
-----
-
-[discrete]
-=== Use Docker or Podman with Docker Compose
-
-Assumptions:
-
-* [x] {uri-docker-get-started}[Docker] *or* {uri-podman-get-started}[Podman 3] is installed on your machine.
-      Note the mutual exclusivity.
-* [x] {uri-docker-compose-install}[Docker Compose] is installed
-
-Run:
-
-[source,docker-cli]
-docker-compose up -d
-
-[discrete]
-=== Use Podman with podman-compose
-
-Assumptions:
-
-* [x] {uri-podman-get-started}[Podman] is installed on your machine.
-* [x] {uri-podman-compose-install}[Podman-Compose] is installed on your machine.
-
-Run:
-
-[source,podman-cli]
-podman-compose up -d
-
-[discrete]
-=== Testing after starting
-
-After starting the containers the servers will be available on your host at: `{uri-localhost-8000}`
+Find how to make a manual installation on the xref:manual-install.adoc[Manual installation] page.
 
 [#images]
-== Images
+== [[kroki-container-images]]Kroki container images
+Kroki container images are published on the https://hub.docker.com/u/yuzutech[Docker Hub] registry and are the:
 
-[#yuzutech-kroki]
-{uri-docker-kroki-image}[yuzutech/kroki] image contains the following diagrams libraries out-of-the-box:
+* Mandatory <<The "kroki" container,"kroki" container>> that provides the gateway server and a large number of diagrams.
+* _Optional_ <<Companion containers,companion containers>> that provide additional diagrams.
+  Please note that you need the gateway server to interact with them.
+
+== [[yuzutech-kroki]]The "kroki" container
+The `yuzutech/kroki` container is the only container that must be running for a minimal install.
+
+The {uri-docker-kroki-image}[yuzutech/kroki] image contains the gateway server, and the following diagram libraries out-of-the-box:
 
 * https://bytefield-svg.deepsymmetry.org/[Bytefield]
 * http://ditaa.sourceforge.net[Ditaa]
@@ -199,11 +104,19 @@ In other words, the following endpoints will be available:
 /wavedrom
 ....
 
-If you want to use additional diagrams (such as _BlockDiag_, _Mermaid_, _Excalidraw_ or _BPMN_), then you will also need to start companion containers:
+If you want to use additional diagram libraries (such as _BlockDiag_, _BPMN_, _Excalidraw_ or _Mermaid_), then you will also need to start their companion containers:
+
+== Companion containers
+These optional companion containers provide additional diagrams and require the gateway server
+
+// * <<yuzutech-kroki-blockdiag,Kroki blockdiag>>
+// * <<yuzutech-kroki-bpmn,Kroki bpmn>>
+// * <<yuzutech-kroki-excalidraw,Kroki excalidraw>>
+// * <<yuzutech-kroki-mermaid,Kroki mermaid>>
 
 [#yuzutech-kroki-blockdiag]
 {uri-docker-kroki-blockdiag-image}[yuzutech/kroki-blockdiag^]::
-Provides block, sequence, activity and network diagrams for Kroki using respectively
+Provides block, sequence, activity, network, packet & equipment rack diagrams for Kroki using respectively the
 {uri-blockdiag}[BlockDiag^],
 {uri-seqdiag}[SeqDiag^],
 {uri-actdiag}[ActDiag^],
@@ -211,131 +124,15 @@ Provides block, sequence, activity and network diagrams for Kroki using respecti
 {uri-packetdiag}[PacketDiag^],
 and {uri-rackdiag}[RackDiag^] libraries.
 
-[#yuzutech-kroki-mermaid]
-{uri-docker-kroki-mermaid-image}[yuzutech/kroki-mermaid^]::
-Provides flowchart, sequence and Gantt diagrams for Kroki using {uri-mermaid}[Mermaid^].
-
 [#yuzutech-kroki-bpmn]
 {uri-docker-kroki-bpmn-image}[yuzutech/kroki-bpmn^]::
-Provides BPMN diagrams for Kroki using {uri-bpmn}[bpmn-js^].
+Provides BPMN diagrams for Kroki using the {uri-bpmn}[bpmn-js^] library.
 
 [#yuzutech-kroki-excalidraw]
 {uri-docker-kroki-excalidraw-image}[yuzutech/kroki-excalidraw^]::
-Provides BPMN diagrams for Kroki using {uri-excalidraw}[Excalidraw^].
+Provides hand-drawn diagrams for Kroki using the {uri-excalidraw}[Excalidraw^] library.
 
-== Use Kubernetes
+[#yuzutech-kroki-mermaid]
+{uri-docker-kroki-mermaid-image}[yuzutech/kroki-mermaid^]::
+Provides flowchart, sequence and Gantt diagrams for Kroki using the {uri-mermaid}[Mermaid^] library.
 
-This section will explain how to install Kroki on Kubernetes using the `default` namespace.
-
-[IMPORTANT]
-====
-To allow external access to your Kroki internal service,
-you will to publish the service using `ClusterIP`, `NodePort`, `LoadBalancer` or `ExternalName`.
-
-In this example, we will use `Ingress` to expose the service on port 8000.
-
-To learn more about how to publish a service, please consult the {uri-k8s-publish-service}[Kubernetes documentation]
-====
-
-You can link:{attachmentsdir}/kroki-k8s.zip[download a bundle (zip file)] that contains all the required `Deployment`, `Service` and `Ingress` definition files to deploy Kroki on Kubernetes.
-
-Once you've downloaded the .zip file, extract the content of the zip file into a folder named _kroki-k8s_.
-
-[TIP]
-====
-If you have `wget` and `unzip` installed on your machine, open a terminal and type:
-
-[source,cli]
-----
-wget http://docs.kroki.io/kroki/setup/_attachments/kroki-k8s.zip -O kroki-k8s.zip
-unzip kroki-k8s.zip -d kroki-k8s
-----
-The above commands will download the zip file and extract it into a folder named _kroki-k8s_.
-====
-
-Use the command `kubectl apply` to create all the required Kubernetes objects:
-
-[source,cli]
-----
-kubectl apply -f /path/to/kroki-k8s
-----
-
-Do not forget to replace `/path/to/kroki-k8s` with the actual path to the folder that contains the definition files (`.yaml`)
-
-Alternatively, you install them individually from GitHub, open a terminal and type:
-
-.Add BlockDiag service
-[source,cli,subs=+attributes]
-----
-kubectl apply -f {uri-k8s-definition-files}/blockdiag-deployment.yaml
-kubectl apply -f {uri-k8s-definition-files}/blockdiag-service.yaml
-----
-
-.Add Mermaid service
-[source,cli,subs=+attributes]
-----
-kubectl apply -f {uri-k8s-definition-files}/mermaid-deployment.yaml
-kubectl apply -f {uri-k8s-definition-files}/mermaid-service.yaml
-----
-
-.Add BPMN service
-[source,cli,subs=+attributes]
-----
-kubectl apply -f {uri-k8s-definition-files}/bpmn-deployment.yaml
-kubectl apply -f {uri-k8s-definition-files}/bpmn-service.yaml
-----
-
-.Add Excalidraw service
-[source,cli,subs=+attributes]
-----
-kubectl apply -f {uri-k8s-definition-files}/excalidraw-deployment.yaml
-kubectl apply -f {uri-k8s-definition-files}/excalidraw-service.yaml
-----
-
-.Add Kroki service
-[source,cli,subs=+attributes]
-----
-kubectl apply -f {uri-k8s-definition-files}/kroki-deployment.yaml
-kubectl apply -f {uri-k8s-definition-files}/kroki-service.yaml
-----
-
-.Add Ingress
-[source,cli,subs=+attributes]
-kubectl apply -f {uri-k8s-definition-files}/kroki-ingress.yaml
-
-Verify that Kroki service is running using `kubectl get pod`:
-
-[source,cli]
-kubectl get pod
-
-If the installation was successful, the command should report a list of running pods:
-
-....
-NAME                          READY   STATUS    RESTARTS   AGE
-blockdiag-7bd6c989b7-zhvj8    1/1     Running   0          24s
-bpmn-6cfccf9bc4-6w4px         1/1     Running   0          24s
-excalidraw-5b84995fcb-dh57t   1/1     Running   0          24s
-kroki-6b49bcb7c4-x2ksc        1/1     Running   0          23s
-mermaid-7bff5c9959-hkrxx      1/1     Running   0          22s
-....
-
-To make sure that Kroki is working, open a terminal and type:
-
-[source,cli]
-kubectl port-forward service/kroki 8000:8000
-
-The above command will forward local port 8000 to port 8000 on the `service/kroki` Pod.
-In other words, Kroki will be accessible on localhost:8000.
-
-Open a second terminal and type:
-
-[source,cli]
-curl http://localhost:8000/seqdiag/svg/eNorTi1MyUxMV6jmUlBIKsovL04tUtC1UyhPTQKyyoCc6JzEpNQcBVsFJXfXEAX9zLyU1Aq9jJLcHKVYayQ9Nrq6CE3WhA0L8A8GmpaUk5-un5yfm5uaVwIxD6EWqDElsSQxKbE4FUmfp1-wa1CIAg49IFfANOFxXS0A68hQUg==
-
-[NOTE]
-=====
-To uninstall Kroki, you can use the command `kubectl delete`:
-
-[source,cli]
-kubectl delete -f /path/to/kroki-k8s
-=====

--- a/docs/modules/setup/pages/use-docker-or-podman.adoc
+++ b/docs/modules/setup/pages/use-docker-or-podman.adoc
@@ -1,0 +1,158 @@
+= Using Docker or Podman
+:uri-docker-container-networking: https://docs.docker.com/config/containers/container-networking/
+:uri-podman-container-networking: https://podman.io/getting-started/network
+:uri-local-kroki-access: http://localhost:8000
+
+This page covers how to install and run Kroki locally using the prebuilt Kroki container images from Docker Hub.
+
+TIP: To get started fast and convert plain text diagrams to images with Kroki,
+you need only to install the gateway server.
+
+We recommend installing and running Kroki locally using containers with either *Docker* or *Podman*, especially if you don't want to manually install diagrams libraries.
+
+On this page, you'll learn:
+
+* [x] How to get started with one container which is the minimum needed to run Kroki
+* [x] How to run Kroki with Docker or Podman using prebuilt Kroki container images from Docker Hub
+* [x] How to run multiple Kroki containers for serving more diagram types.
+
+== Prerequisites
+
+Container software of choice::
+You will need in your environment Docker or Podman software to run the Kroki containers.
++
+Read more about choosing Docker or Podman at xref:about-docker-podman.adoc[].
+
+Kroki containers::
+You will need access to the xref:install.adoc#images[Kroki container images] that are either:
+
+* On Docker Hub via an internet connection
++
+_This guide uses these images._
+* The above Docker Hub images stored locally
+* Your own built Kroki container images
+
+== Install the Kroki gateway server
+
+Installing and running the Kroki gateway server by itself gets you started quickly to begin creating diagrams provided by the xref:install.adoc#yuzutech-kroki[`yuzutech/kroki`] image.
+
+Assumptions:
+
+* [x] {uri-docker-get-started}[Docker] or {uri-podman-get-started}[Podman] is installed on your machine.
+
+To start the Kroki gateway server, run the command:
+
+Using docker::
+
+[source,docker-cli]
+docker run yuzutech/kroki
+
+Using podman::
+
+[source,podman-cli]
+podman run yuzutech/kroki
+
+[IMPORTANT]
+====
+By default, when you start a container, it does not publish any of its ports to the outside world. +
+To make a port available to services outside of Docker or Podman, you need to use the `--publish` or `-p` flag.
+====
+
+[discrete]
+=== Published port
+
+To map a container port to a port on your Docker host, you need to use the `--publish` or `-p` flag.
+
+Using docker::
+
+[source,docker-cli]
+docker run -p8000:8000 yuzutech/kroki
+
+Using podman::
+
+[source,podman-cli]
+podman run -p8000:8000 yuzutech/kroki
+
+After the above command, the server will be available on your host at: `{uri-local-kroki-access}`
+
+[NOTE]
+====
+You can also map a different TCP port on the Docker host.
+For instance, if you want to map your host's TCP port 1234 to port 8000 in the Kroki container, use: `-p1234:8000`.
+
+In this case, the server will be available on your host at: `\http://localhost:1234`
+====
+
+You can read more about {uri-docker-container-networking}[Docker container networking] and {uri-podman-container-networking}[Podman networking] in their documentation.
+
+[discrete]
+=== Detached mode
+
+The previous methods above ran the containers in the foreground, requiring you to press control-c to stop them.
+Starting containers in detached mode runs them in the background, requiring you to use the Docker/Podman `stop` or `kill` command to stop them.
+
+Finally, to start a container in detached mode, you use `-d` option:
+
+Using docker::
+
+[source,docker-cli]
+docker run -p8000:8000 -d yuzutech/kroki
+
+Using podman::
+
+[source,podman-cli]
+podman run -p8000:8000 -d yuzutech/kroki
+
+After the above command, the server will be available on your host at: `{uri-local-kroki-access}`
+
+== Run multiple Kroki containers together
+
+Running multiple containers allows you to use all the diagram features of Kroki in your environment provided by the <<images>>.
+The gateway server container provided by the image <<yuzutech-kroki,`yuzutech/kroki`>> image is the minimum requirement.
+
+[discrete]
+=== Example of running them all together
+
+Here's an example where we start all the Kroki containers together as a group (or pod) in detached mode.
+
+The same Kroki `docker-compose.yml` configuration file below is used by all examples of running the different Kroki containers together.
+
+.docker-compose.yml
+[source,yml]
+----
+include::example$kroki-docker-compose.yml[]
+----
+
+[discrete]
+=== Use Docker or Podman with Docker Compose
+
+Assumptions:
+
+* [x] {uri-docker-get-started}[Docker] *or* {uri-podman-get-started}[Podman 3] is installed on your machine.
+      Note the mutual exclusivity.
+* [x] {uri-docker-compose-install}[Docker Compose] is installed
+
+Run:
+
+[source,docker-cli]
+docker-compose up -d
+
+[discrete]
+=== Use Podman with podman-compose
+
+Assumptions:
+
+* [x] {uri-podman-get-started}[Podman] is installed on your machine.
+* [x] {uri-podman-compose-install}[Podman-Compose] is installed on your machine.
+
+Run:
+
+[source,podman-cli]
+podman-compose up -d
+
+[discrete]
+=== Testing after starting
+
+After starting the containers the servers will be available.
+
+Test that you see the Kroki services page in your browser on your host at URL: `{uri-local-kroki-access}`

--- a/docs/modules/setup/pages/use-kubernetes.adoc
+++ b/docs/modules/setup/pages/use-kubernetes.adoc
@@ -1,0 +1,151 @@
+= Use Kubernetes
+//:uri-k8s-kroki-examples: https://raw.githubusercontent.com/yuzutech/kroki/master/docs/modules/setup/examples/k8s
+:uri-k8s-kroki-examples: {examplesdir}/k8s
+:uri-k8s-docs-publish-service: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
+
+This section describes how to install Kroki on Kubernetes using the `default` namespace.
+
+On this page you will find how to:
+
+* [x] Use `Ingress` to expose the service on port 8000.
+* [x] Download and extract the example Kroki kubernetes definition files
+* [x] Install the Kubernetes objects as a batch or one by one.
+* [x] Validate the installation
+* [x] Delete the Kroki installation
+
+.Providing external access to Kroki
+[IMPORTANT]
+====
+To allow external access to your Kroki internal service,
+you publish the service using `ClusterIP`, `NodePort`, `LoadBalancer` or `ExternalName`.
+
+This example uses `Ingress` to expose the service on port 8000.
+
+Read more about how to publish a service on the {uri-k8s-docs-publish-service}[Kubernetes documentation] website.
+====
+
+== Extract the Kubernetes object definition files
+Prepare the Kubernetes definition files by doing the following:
+
+. Download the example bundle link:{attachmentsdir}/kroki-k8s.zip[`kroki-k8s.zip`] that contains all the required `Deployment`, `Service` and `Ingress` definition files to deploy Kroki on Kubernetes.
++
+.Example command with `wget` installed
+[source,cli]
+----
+wget http://docs.kroki.io/kroki/setup/_attachments/kroki-k8s.zip -O kroki-k8s.zip
+----
+
+. Extract the contents of the above zip file into a folder named `kroki-k8s`.
++
+.Example command with `unzip` installed
+[source,cli]
+----
+unzip kroki-k8s.zip -d kroki-k8s
+----
+
+
+
+In the next steps you use the `*.yml` files beneath the directory `kroki-k8s` and apply them in batch or individually, to create the Kubernetes objects.
+
+== Create objects as a batch
+To install (create) all the Kubernetes objects in a batch do the following:
+
+Use the command `kubectl apply` to create all the required Kubernetes objects,
+replacing _/path/to/kroki-k8s_ with the path to the folder containing the `*.yaml` definition files.
+
+.Example command
+[source,cli,subs=+quotes]
+----
+kubectl apply -f _/path/to/kroki-k8s_
+----
+
+Your next step is to <<Validate that Kroki is running>>.
+
+Read more about working with kubernetes objects on the https://kubernetes.io/docs/concepts/overview/working-with-objects/kubernetes-objects/[Kubernetes] website.
+
+== Create objects individually
+Alternatively they can be applied individually.
+
+To install them individually from GitHub, open a terminal and type commands indicated for each service:
+
+.Add BlockDiag service
+[source,cli,subs=+attributes]
+----
+kubectl apply -f {uri-k8s-kroki-examples}/blockdiag-deployment.yaml
+kubectl apply -f {uri-k8s-kroki-examples}/blockdiag-service.yaml
+----
+
+.Add Mermaid service
+[source,cli,subs=+attributes]
+----
+kubectl apply -f {uri-k8s-kroki-examples}/mermaid-deployment.yaml
+kubectl apply -f {uri-k8s-kroki-examples}/mermaid-service.yaml
+----
+
+.Add BPMN service
+[source,cli,subs=+attributes]
+----
+kubectl apply -f {uri-k8s-kroki-examples}/bpmn-deployment.yaml
+kubectl apply -f {uri-k8s-kroki-examples}/bpmn-service.yaml
+----
+
+.Add Excalidraw service
+[source,cli,subs=+attributes]
+----
+kubectl apply -f {uri-k8s-kroki-examples}/excalidraw-deployment.yaml
+kubectl apply -f {uri-k8s-kroki-examples}/excalidraw-service.yaml
+----
+
+.Add Kroki service
+[source,cli,subs=+attributes]
+----
+kubectl apply -f {uri-k8s-kroki-examples}/kroki-deployment.yaml
+kubectl apply -f {uri-k8s-kroki-examples}/kroki-service.yaml
+----
+
+.Add Ingress
+[source,cli,subs=+attributes]
+kubectl apply -f {uri-k8s-kroki-examples}/kroki-ingress.yaml
+
+Your next step is to <<Validate that Kroki is running>>.
+
+== Validate that Kroki is running
+After installing the Kroki Kubernetes objects you verify that Kroki is running.
+
+To verify that the Kroki service is running do the following:
+
+. Run the `kubectl get pod` command:
+[source,cli]
+kubectl get pod
++
+If the installation is successful a list of running pods is shown that includes the following:
++
+....
+NAME                          READY   STATUS    RESTARTS   AGE
+blockdiag-7bd6c989b7-zhvj8    1/1     Running   0          24s
+bpmn-6cfccf9bc4-6w4px         1/1     Running   0          24s
+excalidraw-5b84995fcb-dh57t   1/1     Running   0          24s
+kroki-6b49bcb7c4-x2ksc        1/1     Running   0          23s
+mermaid-7bff5c9959-hkrxx      1/1     Running   0          22s
+....
+
+. To make sure that Kroki is working, open a terminal and type:
+[source,cli]
+kubectl port-forward service/kroki 8000:8000
++
+The above command forwards local port 8000 to port 8000 on the `service/kroki` Pod.
+In other words, Kroki is accessible on localhost:8000.
+
+. Open a second terminal and type:
+[source,cli]
+curl http://localhost:8000/seqdiag/svg/eNorTi1MyUxMV6jmUlBIKsovL04tUtC1UyhPTQKyyoCc6JzEpNQcBVsFJXfXEAX9zLyU1Aq9jJLcHKVYayQ9Nrq6CE3WhA0L8A8GmpaUk5-un5yfm5uaVwIxD6EWqDElsSQxKbE4FUmfp1-wa1CIAg49IFfANOFxXS0A68hQUg==
++
+If successful, a diagram is shown.
+
+== Uninstall Kroki
+If you installed Kroki using the downloaded and unpacked `*.yaml` files, Kroki can be deleted using those same files.
+
+To uninstall Kroki use the command `kubectl delete` as follows:
+
+[source,cli,subs=+quotes]
+kubectl delete -f _/path/to/kroki-k8s_


### PR DESCRIPTION
Pull request for issue #828

Make the install documentation as follows:

> Install
> - Using Docker or Podman
> - Using Kubernetes
> - Manual install

To preserve contributor history, instead of just copying the content to the new files, this method is used: https://devblogs.microsoft.com/oldnewthing/20190919-00/?p=102904

Modifications to date:
After removing any unused attributes from the split out pages, those remaining are only used on the page where they are defined. I didn't see the need to propagate any to the `antora.yml` file as yet. If it should happen that this is not the case then it would be good to move them.

Install page:
- Remove redundant content from the page.
- Rework the introductions to the page and installation methods.
- Standardise styles for linking to pages and sites.
- Distinguish between the gateway and companion server images in the images section.
- Create a leading index to the Kroki container images.

Use Docker or Podman page:
- Rename attribute :uri-localhost-8000: to a more meaninful :uri-local-kroki-access:

Kubernetes page:
- Use {examplesdir}/k8s to refer to the individual definition yaml files.
- Refactor to have sections
- Match the same style as the other docs.