### PR TITLE
resolves #842 creates SVG and PNG error images

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,6 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.kroki</groupId>
   <artifactId>kroki</artifactId>
+  <name>kroki</name>
   <packaging>pom</packaging>
   <version>0.14.0</version>
   <properties>
@@ -29,5 +30,4 @@
       </plugin>
     </plugins>
   </build>
-  <name>kroki</name>
 </project>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -81,6 +81,11 @@
       <version>${plantuml.version}</version>
     </dependency>
     <dependency>
+      <groupId>guru.nidi.com.kitfox</groupId>
+      <artifactId>svgSalamander</artifactId>
+      <version>1.1.3</version>
+    </dependency>
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
       <version>${junit.jupiter.version}</version>
@@ -108,6 +113,7 @@
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <version>${mockito-core.version}</version>
+      <scope>test</scope>
     </dependency>
     <!--
     Due to a bug in JDK 8 we need to add vertx-codegen as a test dependency otherwise the following exception is thrown:
@@ -131,18 +137,6 @@
       <groupId>io.vertx</groupId>
       <artifactId>vertx-junit5</artifactId>
       <version>${vertx.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.xmlgraphics</groupId>
-      <artifactId>batik-transcoder</artifactId>
-      <version>1.14</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.twelvemonkeys.imageio</groupId>
-      <artifactId>imageio-batik</artifactId>
-      <version>3.7.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/server/src/main/java/io/kroki/server/error/ErrorImage.java
+++ b/server/src/main/java/io/kroki/server/error/ErrorImage.java
@@ -1,0 +1,95 @@
+package io.kroki.server.error;
+
+import com.kitfox.svg.SVGDiagram;
+import com.kitfox.svg.SVGElement;
+import com.kitfox.svg.SVGException;
+import com.kitfox.svg.SVGUniverse;
+import com.kitfox.svg.app.beans.SVGIcon;
+
+import java.awt.Dimension;
+import java.awt.Graphics2D;
+import java.awt.geom.Rectangle2D;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+
+public class ErrorImage {
+
+  public static SVGWithDimension buildSVGImage(String errorMessage) throws IOException, SVGException {
+    String[] lines = errorMessage.split("\\n");
+    StringBuilder text = new StringBuilder();
+    String fontSize = "16";
+    String fontFamily = "BlinkMacSystemFont, -apple-system, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Fira Sans', 'Droid Sans', 'Helvetica Neue', 'Helvetica', Arial, sans-serif";
+    for (String line : lines) {
+      // QUESTION: should we use ellipsis or force break if line length is too long?
+      text.append("<tspan x=\"10\" dy=\"").append(fontSize).append("\">").append(line).append("</tspan>\n");
+    }
+    String svg = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n" +
+      "<svg xmlns=\"http://www.w3.org/2000/svg\" version=\"1.1\">\n" +
+      "<rect fill=\"#fff5f7\" width=\"100%\" height=\"100%\"/>\n" +
+      "<text id=\"text\" xml:space=\"preserve\" font-weight=\"bold\" fill=\"#cd0930\" font-family=\"" + fontFamily + "\" font-size=\"" + fontSize + "px\" x=\"0\" y=\"5\" dy=\"0\">\n" +
+      text +
+      "</text>\n" +
+      "<rect fill=\"#ff3860\" width=\"3\" height=\"100%\"/>\n" +
+      "</svg>";
+    Dimension dimension = computeDimension(svg);
+    String result = svg
+      .replaceAll("<svg xmlns=.*>\\n", "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"" + dimension.width + "\" height=\"" + dimension.height + "\" viewBox=\"0 0 " + dimension.width + " " + dimension.height + "\" version=\"1.1\">\n")
+      .replaceAll("width=\"100%\"", "width=\"" + dimension.width + "\"")
+      .replaceAll("height=\"100%\"", "height=\"" + dimension.height + "\"");
+    return new SVGWithDimension(result, dimension);
+  }
+
+  public static BufferedImage buildPNGImage(String errorMessage) throws IOException, SVGException {
+    SVGWithDimension svgWithDimension = buildSVGImage(errorMessage);
+    try (ByteArrayInputStream svgInputStream = new ByteArrayInputStream(svgWithDimension.source.getBytes(StandardCharsets.UTF_8))) {
+      SVGUniverse svgUniverse = new SVGUniverse();
+      URI svgUri = svgUniverse.loadSVG(svgInputStream, "error-message");
+      SVGDiagram diagram = svgUniverse.getDiagram(svgUri);
+      SVGIcon svgIcon = new SVGIcon();
+      svgIcon.setSvgUniverse(svgUniverse);
+      svgIcon.setSvgURI(svgUri);
+      svgIcon.setAntiAlias(true);
+      svgIcon.setInterpolation(SVGIcon.INTERP_BICUBIC);
+      int width = (int) diagram.getWidth();
+      int height = (int) diagram.getHeight();
+      BufferedImage image = new BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB);
+      Graphics2D g = image.createGraphics();
+      g.setClip(0, 0, width, height);
+      svgIcon.paintIcon(null, g, 0, 0);
+      g.dispose();
+      return image;
+    }
+  }
+
+  private static Dimension computeDimension(String svg) throws IOException, SVGException {
+    try (ByteArrayInputStream svgInputStream = new ByteArrayInputStream(svg.getBytes(StandardCharsets.UTF_8))) {
+      SVGUniverse svgUniverse = new SVGUniverse();
+      URI svgUri = svgUniverse.loadSVG(svgInputStream, "error-message");
+      SVGDiagram diagram = svgUniverse.getDiagram(svgUri);
+      SVGElement textElement = diagram.getElement("text");
+      Rectangle2D bbox = textElement.getRoot().getBoundingBox();
+      return new Dimension((int) Math.floor(bbox.getWidth() + bbox.getX()) + 10, (int) Math.floor(bbox.getHeight() + bbox.getY()) + 5);
+    }
+  }
+
+  public static class SVGWithDimension {
+    private final String source;
+    private final Dimension dimension;
+
+    public SVGWithDimension(String source, Dimension dimension) {
+      this.source = source;
+      this.dimension = dimension;
+    }
+
+    public String getSource() {
+      return source;
+    }
+
+    public Dimension getDimension() {
+      return dimension;
+    }
+  }
+}

--- a/server/src/test/java/io/kroki/server/ErrorImageTest.java
+++ b/server/src/test/java/io/kroki/server/ErrorImageTest.java
@@ -1,0 +1,24 @@
+package io.kroki.server;
+
+import com.kitfox.svg.SVGException;
+import io.kroki.server.error.ErrorImage;
+import org.junit.jupiter.api.Test;
+
+import java.awt.Dimension;
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ErrorImageTest {
+
+  @Test
+  public void should_generate_svg_error_image() throws IOException, SVGException {
+    ErrorImage.SVGWithDimension svgWithDimension = ErrorImage.buildSVGImage("There is no layout engine support for \"nfds\"\nUse one of: circo dot fdp neato nop nop1 nop2 osage patchwork sfdp twopi");
+    Dimension dimension = svgWithDimension.getDimension();
+    assertThat(dimension.width).isGreaterThan(500);
+    assertThat(dimension.height).isGreaterThan(40);
+    assertThat(svgWithDimension.getSource()).contains("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n");
+    assertThat(svgWithDimension.getSource()).contains("<tspan x=\"10\" dy=\"16\">There is no layout engine support for \"nfds\"</tspan>\n");
+    assertThat(svgWithDimension.getSource()).contains("<tspan x=\"10\" dy=\"16\">Use one of: circo dot fdp neato nop nop1 nop2 osage patchwork sfdp twopi</tspan>\n");
+  }
+}


### PR DESCRIPTION
Use svgSalamander to create SVG and PNG images.
For reference, Batik adds ~7mb of dependencies.


resolves #842