### PR TITLE
Use HeaderParser to parse Accept header

### DIFF
--- a/server/src/main/java/io/kroki/server/error/ErrorContext.java
+++ b/server/src/main/java/io/kroki/server/error/ErrorContext.java
@@ -1,8 +1,10 @@
 package io.kroki.server.error;
 
+import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.ext.web.MIMEHeader;
+import io.vertx.ext.web.impl.HeaderParser;
 import io.vertx.ext.web.impl.ParsableMIMEValue;
 
 import java.util.List;
@@ -17,7 +19,7 @@ public class ErrorContext {
   private final String statusMessage;
 
   public ErrorContext(HttpServerRequest request, HttpServerResponse response, String statusMessage, ErrorInfo errorInfo) {
-    this.acceptableMimes = request.headers().getAll("accept").stream().map(ParsableMIMEValue::new).collect(Collectors.toList());
+    this.acceptableMimes = HeaderParser.sort(HeaderParser.convertToParsedHeaderValues(request.getHeader(HttpHeaders.ACCEPT), ParsableMIMEValue::new));
     this.request = request;
     this.response = response;
     // no new lines are allowed in the status message


### PR DESCRIPTION
Otherwise, Kroki does not return an error image when the Accept header contains more than one MIME-type.
Reference #842