### PR TITLE
Use Python-version agnostic helpers

### DIFF
--- a/docs/modules/setup/pages/usage.adoc
+++ b/docs/modules/setup/pages/usage.adoc
@@ -21,7 +21,7 @@ digraph G {
 Here we are using a Python one-liner to encode our diagram using deflate + base64:
 
 [source,cli]
-cat hello.dot | python -c "import sys; import base64; import zlib; print(base64.urlsafe_b64encode(zlib.compress(sys.stdin.read(), 9)))"
+cat hello.dot | python -c "import sys; import base64; import zlib; print(base64.urlsafe_b64encode(zlib.compress(sys.stdin.read().encode('utf-8'), 9)).decode('ascii'))"
 
 The above command will return `eNpLyUwvSizIUHBXqPZIzcnJ17ULzy_KSanlAgB1EAjQ`.
 We can then copy this value in the URL:

--- a/server/README.adoc
+++ b/server/README.adoc
@@ -90,7 +90,7 @@ For example:
 $ mkdir example-lib
 $ printf "@startuml\nBob->Alice\n@enduml\n" > example-lib/bob.puml
 $ sudo docker run --publish=8000:8000 -v $(pwd)/example-lib:/example-lib -e KROKI_SAFE_MODE=SAFE -e KROKI_PLANTUML_INCLUDE_PATH=/example-lib yuzutech/kroki:latest
-$ curl http://localhost:8000/plantuml/svg/$(printf '@startuml\n!include bob.puml\nAlice -> Bob\n@enduml' | python -c "import sys; import base64; import zlib; print(base64.urlsafe_b64encode(zlib.compress(sys.stdin.read(), 9)))")
+$ curl http://localhost:8000/plantuml/svg/$(printf '@startuml\n!include bob.puml\nAlice -> Bob\n@enduml' | python -c "import sys; import base64; import zlib; print(base64.urlsafe_b64encode(zlib.compress(sys.stdin.read().encode('utf-8'), 9)).decode('ascii'))")
 ----
 
 == Manual install


### PR DESCRIPTION

As it may not be the default `python` on an OS any more, we should make
it possible to run against Python 2 and Python 3.

