### PR TITLE
Shrink docker build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.git/
+*.iml
+.vertx/
+**/node_modules/


### PR DESCRIPTION
During `make buildDockerImages`, I noticed that 1.8GB (or GO :wink:) have to be sent to the docker builder. This significantly reduces the context that has to be transferred.