### PR TITLE
#1219 Add an example for enabling SSL.

### DIFF
--- a/docs/modules/setup/pages/configuration.adoc
+++ b/docs/modules/setup/pages/configuration.adoc
@@ -201,11 +201,38 @@ When SSL is enabled, you must provide the certificate and the private key values
 ====
 You can generate a self-signed SSL certificate and private key as PEM format using `openssl`:
 
-  $ openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -days 365
+[source,bash]
+----
+openssl req -nodes -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -days 365
+----
 
 The above command will generate two files, `cert.pem` containing the certificate and `key.pem` containing the private key.
 
-You can then set the `KROKI_SSL_CERT` environment variable with the contents of the `cert.pem` file and set the `KROKI_SSL_KEY` environment variable with the contents of the `key.pem` file.
+You can then write the `KROKI_SSL_CERT` environment variable with the contents of the `cert.pem` file and the `KROKI_SSL_KEY` environment variable with the contents of the `key.pem` to an environment-file:
+
+[source,bash]
+----
+cat cert.pem | tr -d '\n' | sed 's/^/KROKI_SSL_CERT=/' >> .env
+echo >> .env
+cat key.pem | tr -d '\n' | sed 's/^/KROKI_SSL_KEY=/' >> .env
+----
+
+The container can then be started with the environment variables set accordingly:
+
+Using docker::
+
+[source,bash]
+----
+docker run -p8000:8000 -e KROKI_SSL=true --env-file=.env yuzutech/kroki
+----
+
+Using podman::
+
+[source,bash]
+----
+podman run -p8000:8000 -e KROKI_SSL=true --env-file=.env yuzutech/kroki
+----
+
 ====
 
 If SSL is enabled, both `KROKI_SSL_KEY` and `KROKI_SSL_CERT` must be configured.

--- a/docs/modules/setup/pages/configuration.adoc
+++ b/docs/modules/setup/pages/configuration.adoc
@@ -220,14 +220,14 @@ cat key.pem | tr -d '\n' | sed 's/^/KROKI_SSL_KEY=/' >> .env
 The container can then be started with the environment variables set accordingly:
 
 Using docker::
-
++
 [source,bash]
 ----
 docker run -p8000:8000 -e KROKI_SSL=true --env-file=.env yuzutech/kroki
 ----
 
 Using podman::
-
++
 [source,bash]
 ----
 podman run -p8000:8000 -e KROKI_SSL=true --env-file=.env yuzutech/kroki


### PR DESCRIPTION
Hello,

as discussed in #1219, I have added example commands for running kroki in podman/docker with SSL.

If you have suggestions for improvement, please let me know.