### PR TITLE
Align 'unsupported output format' error messages

### DIFF
--- a/server/src/main/java/io/kroki/server/error/UnsupportedFormatException.java
+++ b/server/src/main/java/io/kroki/server/error/UnsupportedFormatException.java
@@ -9,7 +9,7 @@ public class UnsupportedFormatException extends BadRequestException {
   private final String messageHTML;
 
   public UnsupportedFormatException(String outputFormat, String serviceName, List<FileFormat> supportedFormat) {
-    super(String.format("Unsupported output format: %s. Must be one of %s for %s.", outputFormat, serviceName, FileFormat.stringify(supportedFormat)));
+    super(String.format("Unsupported output format: %s for %s. Must be one of %s.", outputFormat, serviceName, FileFormat.stringify(supportedFormat)));
     this.messageHTML = String.format("Unsupported output format: <code>%s</code> for <i>%s</i>. Must be one of %s.", outputFormat, serviceName, FileFormat.htmlify(supportedFormat));
   }
 


### PR DESCRIPTION
Updates the "unsupported output format" error message for non-HTML responses to be aligned with the HTML response.

The previous implementation caused the `serviceName` to be used in place of the `supportedFormat` and vice versa, e.g. `Unsupported output format: jpg. Must be one of mermaid for png or svg.`

The other option would have been to swap the arguments, but I figured the consistent error message was preferred.