### PR TITLE
Add Julia integration to third-party tools in the documentation

### DIFF
--- a/docs/modules/setup/pages/third-party-tools.adoc
+++ b/docs/modules/setup/pages/third-party-tools.adoc
@@ -10,6 +10,11 @@
 :url-gitlab-int: https://docs.gitlab.com/ce/administration/integration/kroki.html
 :url-sphinx: https://www.sphinx-doc.org/
 :url-sphinx-int: https://github.com/sphinx-contrib/kroki
+:url-julia: https://julialang.org
+:url-julia-documenter: https://juliadocs.github.io/Documenter.jl/stable
+:url-julia-int: https://bauglir.github.io/Kroki.jl/stable
+:url-julia-pluto: https://github.com/fonsp/Pluto.jl
+:url-julia-vscode: https://www.julia-vscode.org
 
 A list of third party tools, developed by the community, that rely on Kroki.
 
@@ -59,3 +64,8 @@ The following {url-vscode}[Visual Studio Code] plugins support Kroki:
 == Sphinx Documentation
 
 There is an {url-sphinx-int}[Kroki integration] for the {url-sphinx}[Sphinx documentation generator].
+
+== Julia
+
+The {url-julia-int}[Kroki.jl] package provides integrations for the {url-julia}[Julia programming language].
+It enables rendering diagrams in environments such as {url-julia-documenter}[Documenter.jl], {url-julia-pluto}[Pluto notebooks] and Julia's {url-julia-vscode}[Visual Studio Code integration].


### PR DESCRIPTION
I'm the maintainer of [Kroki.jl](https://bauglir.github.io/Kroki.jl/stable) and, having just released a new version of the package, I was hoping you'd consider including the package in the list of third-party tools that rely on Kroki.

The Julia package makes it easy to integrate diagrams that are supported by Kroki throughout the Julia ecosystem, e.g. in documentation, notebooks, etc.