### PR TITLE
resolves #970 use cargo.toml to install svgbob

### DIFF
--- a/server/ops/docker/Cargo.toml
+++ b/server/ops/docker/Cargo.toml
@@ -1,0 +1,4 @@
+# Specify svgbob_cli via Cargo.toml so that Renovate can help with updates
+
+[dependencies]
+svgbob_cli = "0.5.3"

--- a/server/ops/docker/build-static-svgbob
+++ b/server/ops/docker/build-static-svgbob
@@ -1,4 +1,7 @@
 # build static executable binary
 FROM ekidd/rust-musl-builder:1.56.1
+COPY Cargo.toml .
 
-RUN cargo install --quiet --version 0.5.3 svgbob_cli
+RUN SVGBOB_VERSION=`cat Cargo.toml | grep "svgbob_cli =" | sed -r 's/.*"([^"]+)"/\1/'` \
+  && cargo install --quiet --version $SVGBOB_VERSION svgbob_cli
+


### PR DESCRIPTION
Addresses #970 by converting the build-static-svgbob to use a Cargo.toml file instead of specifying version directly

I wasn't able to get a full build of kroki to run on my machine but this did seem to work correctly with `COPY --from=kroki-builder-static-svgbobs:latest /home/rust/.cargo/bin/svgbob /usr/bin/svgbob` from `server/ops/docker/jdk11-alpine/Dockerfile`