### PR TITLE
chore(build-deps): use official builder image(rust-musl-builder:1.57.0 to rust:1.64-slim-bullseye)

### DIFF
--- a/server/ops/docker/build-static-svgbob
+++ b/server/ops/docker/build-static-svgbob
@@ -1,7 +1,7 @@
 # build static executable binary
-FROM ekidd/rust-musl-builder:1.56.1
+FROM rust:1.64-slim-bullseye AS builder
+RUN rustup target add x86_64-unknown-linux-musl
 COPY Cargo.toml .
 
 RUN SVGBOB_VERSION=`cat Cargo.toml | grep "svgbob_cli =" | sed -r 's/.*"([^"]+)"/\1/'` \
   && cargo install --quiet --version $SVGBOB_VERSION svgbob_cli
-

--- a/server/ops/docker/build-static-svgbob
+++ b/server/ops/docker/build-static-svgbob
@@ -4,4 +4,4 @@ RUN rustup target add x86_64-unknown-linux-musl
 COPY Cargo.toml .
 
 RUN SVGBOB_VERSION=`cat Cargo.toml | grep "svgbob_cli =" | sed -r 's/.*"([^"]+)"/\1/'` \
-  && cargo install --quiet --version $SVGBOB_VERSION svgbob_cli
+  && cargo install --quiet --target x86_64-unknown-linux-musl --version $SVGBOB_VERSION svgbob_cli

--- a/server/ops/docker/jdk11-alpine/Dockerfile
+++ b/server/ops/docker/jdk11-alpine/Dockerfile
@@ -3,7 +3,7 @@ FROM eclipse-temurin:11.0.16.1_1-jre-alpine
 
 RUN addgroup -g 1000 kroki && adduser -D -G kroki -u 1000 kroki
 
-COPY --from=kroki-builder-static-svgbob:latest /home/rust/.cargo/bin/svgbob /usr/bin/svgbob
+COPY --from=kroki-builder-static-svgbob:latest /usr/local/cargo/bin/svgbob /usr/bin/svgbob
 COPY --from=kroki-builder-static-erd:latest /root/.local/bin/erd /usr/bin/erd
 COPY --from=kroki-builder-nomnoml:latest /app/app.bin /usr/bin/nomnoml
 COPY --from=kroki-builder-vega:latest /app/app.bin /usr/bin/vega


### PR DESCRIPTION
- using official builder image
  - reduce [Supply_chain_attack](https://en.wikipedia.org/wiki/Supply_chain_attack)
  - rust-musl-builder has [not maintained in a while](https://github.com/emk/rust-musl-builder)

- change svgbob_cli builder image(rust-musl-builder:1.57.0 to rust:1.64-slim-bullseye)
  - fixed: builder binary path
  - filed:  specify target platform(x86_64-unknown-linux-musl)

# sample Dockerfile

```
FROM rust:1.64-slim-bullseye AS builder
RUN rustup target add x86_64-unknown-linux-musl
RUN cargo install svgbob_cli --version 0.6.6 --target x86_64-unknown-linux-musl

FROM alpine:3.16
COPY --from=builder /usr/local/cargo/bin/svgbob_cli /usr/bin/svgbob_cli
```