### PR TITLE
feat: allow mermaid to be configured via some query params

### DIFF
--- a/mermaid/package-lock.json
+++ b/mermaid/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "lodash": "^4.17.21",
         "micro": "9.4.1",
         "pino": "8.8.0",
         "pino-debug": "2.0.0",

--- a/mermaid/package.json
+++ b/mermaid/package.json
@@ -18,15 +18,16 @@
     "url": "https://github.com/yuzutech/kroki.git"
   },
   "dependencies": {
+    "lodash": "^4.17.21",
     "micro": "9.4.1",
     "pino": "8.8.0",
     "pino-debug": "2.0.0",
     "puppeteer": "14.4.1"
   },
   "devDependencies": {
-    "mermaid": "9.3.0",
     "chai": "4.3.7",
     "dirty-chai": "^2.0.1",
+    "mermaid": "9.3.0",
     "mocha": "10.2.0",
     "pngjs": "^6.0.0",
     "standard": "17.0.0"

--- a/mermaid/src/index.js
+++ b/mermaid/src/index.js
@@ -12,13 +12,14 @@ const instance = require('./browser-instance')
   const server = micro(async (req, res) => {
     // TODO: add a /_status route (return mermaid version)
     // TODO: read the diagram source as plain text
-    const outputType = req.url.match(/\/(png|svg)$/)?.[1]
+    const url = new URL(req.url, 'http://localhost')  // create a URL object. The base is not important here
+    const outputType = url.pathname.match(/\/(png|svg)$/)?.[1]
     if (outputType) {
       const diagramSource = await micro.text(req, { limit: '1mb', encoding: 'utf8' })
       if (diagramSource) {
         try {
           const isPng = outputType === 'png'
-          const output = await worker.convert(new Task(diagramSource, isPng))
+          const output = await worker.convert(new Task(diagramSource, isPng), url.searchParams)
           res.setHeader('Content-Type', isPng ? 'image/png' : 'image/svg+xml')
           return micro.send(res, 200, output)
         } catch (err) {

--- a/mermaid/src/index.js
+++ b/mermaid/src/index.js
@@ -12,7 +12,7 @@ const instance = require('./browser-instance')
   const server = micro(async (req, res) => {
     // TODO: add a /_status route (return mermaid version)
     // TODO: read the diagram source as plain text
-    const url = new URL(req.url, 'http://localhost')  // create a URL object. The base is not important here
+    const url = new URL(req.url, 'http://localhost') // create a URL object. The base is not important here
     const outputType = url.pathname.match(/\/(png|svg)$/)?.[1]
     if (outputType) {
       const diagramSource = await micro.text(req, { limit: '1mb', encoding: 'utf8' })

--- a/mermaid/src/worker.js
+++ b/mermaid/src/worker.js
@@ -15,12 +15,13 @@ class Worker {
     this.pageUrl = process.env.KROKI_MERMAID_PAGE_URL || `file://${path.join(__dirname, '..', 'assets', 'index.html')}`
   }
 
-  async convert (task) {
+  async convert (task, config) {
     const browser = await puppeteer.connect({
       browserWSEndpoint: this.browserWSEndpoint,
       ignoreHTTPSErrors: true
     })
     const page = await browser.newPage()
+    this.updateConfig(task, config)
     try {
       page.setViewport({ height: 800, width: 600 })
       await page.goto(this.pageUrl)
@@ -62,6 +63,15 @@ class Worker {
         await browser.disconnect()
       } catch (err) {
         logger.warn({ err }, 'Unable to disconnect from the browser')
+      }
+    }
+  }
+
+  updateConfig (task, config) {
+    for (const property in task.mermaidConfig) {
+      // for now only properties with string values are handled
+      if(typeof task.mermaidConfig[property] === 'string') {
+        task.mermaidConfig[property] = config.get(property)
       }
     }
   }

--- a/mermaid/src/worker.js
+++ b/mermaid/src/worker.js
@@ -2,7 +2,7 @@
 const { logger } = require('./logger')
 const path = require('path')
 const puppeteer = require('puppeteer')
-const _ = require('lodash')
+const set = require('lodash/set')
 
 class SyntaxError extends Error {
   constructor () {
@@ -72,7 +72,7 @@ class Worker {
     for (const property in Object.fromEntries(config)) {
       const propertyCamelCase = this.convertPropertyToCamelCase(property)
       const value = this.getTypedValue(config.get(property))
-      _.set(task.mermaidConfig, propertyCamelCase, value)
+      set(task.mermaidConfig, propertyCamelCase, value)
     }
   }
 

--- a/mermaid/src/worker.js
+++ b/mermaid/src/worker.js
@@ -70,19 +70,38 @@ class Worker {
 
   updateConfig (task, config) {
     for (const property in Object.fromEntries(config)) {
-      let value = this.getTypedValue(config.get(property))
-      _.set(task.mermaidConfig, property, value)
+      const propertyCamelCase = this.convertPropertyToCamelCase(property)
+      let value = this.getTypedValue(config.get(propertyCamelCase))
+      _.set(task.mermaidConfig, propertyCamelCase, value)
     }
   }
 
-  getTypedValue(value){
-    if(value.toLowerCase() === 'true' || value.toLocaleString() === 'false'){
-      return  value === 'true'
+  convertPropertyToCamelCase (property) {
+    if (property.startsWith('kroki-diagram-options-')) {
+      const propertySplit = property.substring(22).split('_')
+      for (let i = 0; i < propertySplit.length; i++) {
+        const split = propertySplit[i];
+        const subSplit = split.split('-')
+        if (subSplit.length > 1) {
+          for (let j = 1; j < subSplit.length; j++) {
+            subSplit[j] = subSplit[j].charAt(0).toUpperCase() + subSplit[j].substring(1)
+          }
+          propertySplit[i] = subSplit.join('')
+        }
+      }
+      return propertySplit.join('.')
     }
-    if(value.startsWith('[') && value.endsWith(']')) {
-      return value.substring(1,value.length - 1).split(',').map(item=>this.getTypedValue(item))
+    return property
+  }
+
+  getTypedValue (value) {
+    if (value.toLowerCase() === 'true' || value.toLocaleString() === 'false') {
+      return value === 'true'
     }
-    if(!isNaN(value)){
+    if (value.startsWith('[') && value.endsWith(']')) {
+      return value.substring(1, value.length - 1).split(',').map(item => this.getTypedValue(item))
+    }
+    if (!isNaN(value)) {
       return Number(value)
     }
     return value

--- a/mermaid/src/worker.js
+++ b/mermaid/src/worker.js
@@ -71,7 +71,7 @@ class Worker {
   updateConfig (task, config) {
     for (const property in Object.fromEntries(config)) {
       const propertyCamelCase = this.convertPropertyToCamelCase(property)
-      let value = this.getTypedValue(config.get(property))
+      const value = this.getTypedValue(config.get(property))
       _.set(task.mermaidConfig, propertyCamelCase, value)
     }
   }
@@ -79,7 +79,7 @@ class Worker {
   convertPropertyToCamelCase (property) {
     const propertySplit = property.split('_')
     for (let i = 0; i < propertySplit.length; i++) {
-      const split = propertySplit[i];
+      const split = propertySplit[i]
       const subSplit = split.split('-')
       if (subSplit.length > 1) {
         for (let j = 1; j < subSplit.length; j++) {

--- a/mermaid/src/worker.js
+++ b/mermaid/src/worker.js
@@ -77,21 +77,18 @@ class Worker {
   }
 
   convertPropertyToCamelCase (property) {
-    if (property.startsWith('kroki-diagram-options-')) {
-      const propertySplit = property.substring(22).split('_')
-      for (let i = 0; i < propertySplit.length; i++) {
-        const split = propertySplit[i];
-        const subSplit = split.split('-')
-        if (subSplit.length > 1) {
-          for (let j = 1; j < subSplit.length; j++) {
-            subSplit[j] = subSplit[j].charAt(0).toUpperCase() + subSplit[j].substring(1)
-          }
-          propertySplit[i] = subSplit.join('')
+    const propertySplit = property.split('_')
+    for (let i = 0; i < propertySplit.length; i++) {
+      const split = propertySplit[i];
+      const subSplit = split.split('-')
+      if (subSplit.length > 1) {
+        for (let j = 1; j < subSplit.length; j++) {
+          subSplit[j] = subSplit[j].charAt(0).toUpperCase() + subSplit[j].substring(1)
         }
+        propertySplit[i] = subSplit.join('')
       }
-      return propertySplit.join('.')
     }
-    return property
+    return propertySplit.join('.')
   }
 
   getTypedValue (value) {

--- a/mermaid/src/worker.js
+++ b/mermaid/src/worker.js
@@ -70,7 +70,7 @@ class Worker {
   updateConfig (task, config) {
     for (const property in task.mermaidConfig) {
       // for now only properties with string values are handled
-      if(typeof task.mermaidConfig[property] === 'string') {
+      if(typeof task.mermaidConfig[property] === 'string' && config.get(property)) {
         task.mermaidConfig[property] = config.get(property)
       }
     }

--- a/mermaid/src/worker.js
+++ b/mermaid/src/worker.js
@@ -71,7 +71,7 @@ class Worker {
   updateConfig (task, config) {
     for (const property in Object.fromEntries(config)) {
       const propertyCamelCase = this.convertPropertyToCamelCase(property)
-      let value = this.getTypedValue(config.get(propertyCamelCase))
+      let value = this.getTypedValue(config.get(property))
       _.set(task.mermaidConfig, propertyCamelCase, value)
     }
   }


### PR DESCRIPTION
This PR tries to implement the ability of configuring some options of mermaid using query params of the GET request.

This will only handle properties that have string values and won't handle anything else at the moment. This is mostly because I am not sure how to send configuration values of `flowchart.useMaxWidth`. If there is some clarity on that I can implement that too.

Fixes #1326 