### PR TITLE
Update dbml-renderer

### DIFF
--- a/dbml/package-lock.json
+++ b/dbml/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@softwaretechnik/dbml-renderer": "1.0.22"
+        "@softwaretechnik/dbml-renderer": "1.0.26"
       },
       "bin": {
         "dbml": "index.js"
@@ -115,9 +115,9 @@
       }
     },
     "node_modules/@softwaretechnik/dbml-renderer": {
-      "version": "1.0.22",
-      "resolved": "https://registry.npmjs.org/@softwaretechnik/dbml-renderer/-/dbml-renderer-1.0.22.tgz",
-      "integrity": "sha512-HoRZnA0X1r5Hl/Bmg3RIwQ8Xe75lHznBGBQgjUQ1TmCULZ4qmEMA35L1aL9Vc+6fFxM1ZCSCR7STzF1xmkYFuw==",
+      "version": "1.0.26",
+      "resolved": "https://registry.npmjs.org/@softwaretechnik/dbml-renderer/-/dbml-renderer-1.0.26.tgz",
+      "integrity": "sha512-TkMggVpQqmSQCsj6BPE2lSmKVqTmlmGpkJQzX1M6twbYgd7Bt5v/eRfqKxT6oF3iW66x0C9JwHehejErKkhQCw==",
       "dependencies": {
         "@aduh95/viz.js": "3.4.0",
         "yargs": "^17.5.1"
@@ -2889,9 +2889,9 @@
       }
     },
     "@softwaretechnik/dbml-renderer": {
-      "version": "1.0.22",
-      "resolved": "https://registry.npmjs.org/@softwaretechnik/dbml-renderer/-/dbml-renderer-1.0.22.tgz",
-      "integrity": "sha512-HoRZnA0X1r5Hl/Bmg3RIwQ8Xe75lHznBGBQgjUQ1TmCULZ4qmEMA35L1aL9Vc+6fFxM1ZCSCR7STzF1xmkYFuw==",
+      "version": "1.0.26",
+      "resolved": "https://registry.npmjs.org/@softwaretechnik/dbml-renderer/-/dbml-renderer-1.0.26.tgz",
+      "integrity": "sha512-TkMggVpQqmSQCsj6BPE2lSmKVqTmlmGpkJQzX1M6twbYgd7Bt5v/eRfqKxT6oF3iW66x0C9JwHehejErKkhQCw==",
       "requires": {
         "@aduh95/viz.js": "3.4.0",
         "yargs": "^17.5.1"

--- a/dbml/package.json
+++ b/dbml/package.json
@@ -15,7 +15,7 @@
   "keywords": [],
   "author": "Bruno Obsomer",
   "dependencies": {
-    "@softwaretechnik/dbml-renderer": "1.0.22"
+    "@softwaretechnik/dbml-renderer": "1.0.26"
   },
   "devDependencies": {
     "standard": "17.0.0"

--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -9,7 +9,7 @@ asciidoc:
     bytefield-version: 1.7.0
     c4plantuml-version: 1.2022.5
     d2-version: 0.1.5
-    dbml-version: 1.0.22
+    dbml-version: 1.0.26
     diagramsnet-version: 16.2.4
     ditaa-version: 1.0.3
     erd-version: 0.2.1.0

--- a/server/src/main/java/io/kroki/server/service/Dbml.java
+++ b/server/src/main/java/io/kroki/server/service/Dbml.java
@@ -47,7 +47,7 @@ public class Dbml implements DiagramService {
 
   @Override
   public String getVersion() {
-    return "1.0.22";
+    return "1.0.26";
   }
 
   @Override


### PR DESCRIPTION
Now that https://github.com/softwaretechnik-berlin/dbml-renderer/pull/19 has been merged and released, `dbml-renderer` supports a bigger part of the DBML language.