### PR TITLE
D2: fix incorrect color number for theme 'Neutral grey'

### DIFF
--- a/docs/modules/setup/pages/diagram-options.adoc
+++ b/docs/modules/setup/pages/diagram-options.adoc
@@ -42,7 +42,7 @@ ex. `320x240`
 |theme
 |
 * `default` (`0`)
-* `neutral-grey` (`2`)
+* `neutral-grey` (`1`)
 * `flagship-terrastruct` (`3`)
 * `cool-classics` (`4`)
 * `mixed-berry-blue` (`5`)

--- a/server/src/main/java/io/kroki/server/service/D2.java
+++ b/server/src/main/java/io/kroki/server/service/D2.java
@@ -29,7 +29,7 @@ public class D2 implements DiagramService {
 
   private final Map<String, Integer> builtinThemes = Map.ofEntries(
     entry("default", 0),
-    entry("neutral-grey", 2),
+    entry("neutral-grey", 1),
     entry("flagship-terrastruct", 3),
     entry("cool-classics", 4),
     entry("mixed-berry-blue", 5),


### PR DESCRIPTION
This PR addresses and hopefully closes #1466.