### PR TITLE
Fix: Kroki server, structurizr: remove output format JPEG

### DIFF
--- a/ci/tasks/update-versions.js
+++ b/ci/tasks/update-versions.js
@@ -205,6 +205,15 @@ try {
     }
   }
 
+  const d2GoModContent = await fs.readFile(ospath.join(rootDir, 'server', 'ops', 'docker', 'go.mod'), 'utf8')
+  for (const line of d2GoModContent.split('\n')) {
+    const d2VersionFound = line.match(/^require oss.terrastruct.com\/d2 v(?<version>.+)$/)
+    if (d2VersionFound) {
+      const { version } = d2VersionFound.groups
+      diagramLibraryVersions.d2 = version
+    }
+  }
+
   const svgbobCargoContent = await fs.readFile(ospath.join(rootDir, 'server', 'ops', 'docker', 'Cargo.toml'), 'utf8')
   for (const line of svgbobCargoContent.split('\n')) {
     const svgbobVersionFound = line.match(/^svgbob_cli\s*=\s*"(?<version>.+)"$/)

--- a/ci/tests/smoke.js
+++ b/ci/tests/smoke.js
@@ -11,13 +11,13 @@ const tests = [
   {engine: 'seqdiag', file: 'sequence.diag', options: {}, outputFormat: ['svg', 'png']},
   {engine: 'actdiag', file: 'actions.diag', options: {}, outputFormat: ['svg', 'png']},
   {engine: 'nwdiag', file: 'network.diag', options: {}, outputFormat: ['svg', 'png']},
-  {engine: 'c4plantuml', file: 'banking-system.puml', options: {}, outputFormat: ['svg']},
+  {engine: 'c4plantuml', file: 'banking-system.puml', options: {}, outputFormat: ['svg', 'pdf', 'png', 'txt']},
   {engine: 'dbml', file: 'dbml.dbml', options: {}, outputFormat: ['svg']},
   {engine: 'ditaa', file: 'components.ditaa', options: {}, outputFormat: ['svg']},
   {engine: 'erd', file: 'schema.erd', options: {}, outputFormat: ['svg']},
   {engine: 'mermaid', file: 'contribute.mmd', options: {}, outputFormat: ['svg']},
   {engine: 'bpmn', file: 'example.bpmn', options: {}, outputFormat: ['svg']},
-  {engine: 'plantuml', file: 'architecture.puml', options: {}, outputFormat: ['svg']},
+  {engine: 'plantuml', file: 'architecture.puml', options: {}, outputFormat: ['svg', 'pdf', 'png', 'txt']},
   {engine: 'svgbob', file: 'cloud.bob', options: {}, outputFormat: ['svg']},
   {engine: 'nomnoml', file: 'pirate.nomnoml', options: {}, outputFormat: ['svg']},
   {engine: 'packetdiag', file: 'packet.diag', options: {}, outputFormat: ['svg', 'png']},
@@ -50,7 +50,8 @@ const mimeType = {
   svg: 'image/svg+xml',
   png: 'image/png',
   pdf: 'application/pdf',
-  jpeg: 'image/jpeg'
+  jpeg: 'image/jpeg',
+  txt: 'text/plain'
 }
 
 const sendRequest = async (testCase, outputFormat) => {

--- a/server/ops/docker/jdk11-jammy/Dockerfile
+++ b/server/ops/docker/jdk11-jammy/Dockerfile
@@ -211,6 +211,7 @@ ARG D2_VERSION="0.4.1"
 ARG PLANTUML_VERSION="1.2023.6"
 ARG UMLET_VERSION="2023-03-20_UMLet_v15.1"
 ARG GRAPHVIZ_VERSION="8.0.4"
+ARG GRAPHVIZ_VERSION="8.0.4"
 ARG TARGETARCH
 
 RUN addgroup --gecos 1000 kroki && adduser --disabled-password --ingroup kroki -u 1000 kroki

--- a/server/src/main/java/io/kroki/server/service/Plantuml.java
+++ b/server/src/main/java/io/kroki/server/service/Plantuml.java
@@ -72,7 +72,7 @@ public class Plantuml implements DiagramService {
   private static final Pattern START_BLOCK_RX = Pattern.compile("^(@start.*\\n)");
 
   private static final Logger logger = LoggerFactory.getLogger(Plantuml.class);
-  private static final List<FileFormat> SUPPORTED_FORMATS = Arrays.asList(FileFormat.PNG, FileFormat.SVG, FileFormat.JPEG, FileFormat.BASE64, FileFormat.TXT, FileFormat.UTXT);
+  private static final List<FileFormat> SUPPORTED_FORMATS = Arrays.asList(FileFormat.PNG, FileFormat.SVG, FileFormat.PDF, FileFormat.BASE64, FileFormat.TXT, FileFormat.UTXT);
   private static final Pattern STDLIB_PATH_RX = Pattern.compile("<([a-zA-Z0-9]+)/[^>]+>");
 
   private final Vertx vertx;

--- a/server/src/main/java/io/kroki/server/service/Structurizr.java
+++ b/server/src/main/java/io/kroki/server/service/Structurizr.java
@@ -51,7 +51,7 @@ public class Structurizr implements DiagramService {
   private final PlantumlCommand plantumlCommand;
 
   // same as PlantUML since we convert Structurizr DSL to PlantUML
-  private static final List<FileFormat> SUPPORTED_FORMATS = Arrays.asList(FileFormat.PNG, FileFormat.SVG, FileFormat.JPEG, FileFormat.BASE64, FileFormat.TXT, FileFormat.UTXT);
+  private static final List<FileFormat> SUPPORTED_FORMATS = Arrays.asList(FileFormat.PNG, FileFormat.SVG, FileFormat.PDF, FileFormat.BASE64, FileFormat.TXT, FileFormat.UTXT);
 
   private static final String aws = read("structurizr/amazon-web-services.json");
   private static final String gcp = read("structurizr/google-cloud-platform.json");


### PR DESCRIPTION
When sending a request for a `structurizr` diagram with output format `jpeg`, I'm presented a `Error 500`.
I don't think that `structurizr` supports `jpeg` output format, so we should remove it.