### PR TITLE
Wireviz: Cleanup requirements; update Flask and Werkzeug to 2.2.3

### DIFF
--- a/wireviz/requirements.txt
+++ b/wireviz/requirements.txt
@@ -1,9 +1,11 @@
-Click==8.1.3
-Flask==2.2.2
-funcparserlib==1.0.1
+click==8.1.3
+Flask==2.2.3
 gunicorn==20.1.0
 itsdangerous==2.1.2
-webcolors==1.12
-Werkzeug==2.2.2
+Werkzeug==2.2.3
 wireviz==0.3.2
 graphviz==0.20.1
+Jinja2==3.1.2
+MarkupSafe==2.1.2
+Pillow==9.4.0
+PyYAML==6.0


### PR DESCRIPTION
Cleanup wireviz requirements.txt

* update `Flask` from 2.2.2 to 2.2.3
* update `Werkzeug` from 2.2.2 to 2.2.3
* remove unused `funcparserlib` module
* remove unused `webcolors` module
* add `Jinja2` dependency to version 3.1.2
* add `MarkupSafe` dependency to version 2.1.2
* add `Pillow` dependency to version 9.4.0
* add `PyYAML` dependency to version 6.0
* rename `click` to lower case
