### PR TITLE
Build arm64 main image

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,11 +1,5 @@
 name: CI
 
-inputs:
-  build_multiarch:
-    default: 'false'
-    required: true
-    type: boolean
-
 on:
   push:
     paths-ignore:
@@ -18,6 +12,11 @@ on:
     branches:
       - '*'
   workflow_call:
+    inputs:
+      build_multiarch:
+        default: 'false'
+        required: true
+        type: boolean
 
 jobs:
   test-containers:
@@ -26,7 +25,7 @@ jobs:
     - uses: actions/checkout@v3
     
     - name: Free up disk space
-      if: ${{ github.event.inputs.build_multiarch == 'true' }}
+      if: ${{ inputs.build_multiarch }}
       uses: jlumbroso/free-disk-space@main
       with:
         android: true
@@ -48,15 +47,15 @@ jobs:
       run: make buildServer
 
     - name: Set up QEMU
-      if: ${{ github.event.inputs.build_multiarch == 'true' }}
+      if: ${{ inputs.build_multiarch }}
       uses: docker/setup-qemu-action@v2
 
     - name: Set up Docker Buildx
-      if: ${{ github.event.inputs.build_multiarch == 'false' }}
+      if: ${{ !inputs.build_multiarch }}
       uses: docker/setup-buildx-action@v2
 
     - name: Set up Docker Buildx
-      if: ${{ github.event.inputs.build_multiarch == 'true' }}
+      if: ${{ inputs.build_multiarch }}
       uses: docker/setup-buildx-action@v2
       with:
         config-inline: |

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -24,6 +24,7 @@ jobs:
     - uses: actions/checkout@v3
     
     - name: Free up disk space
+      if: ${{ github.event.inputs.build_multiarch == 'true' }}
       uses: jlumbroso/free-disk-space@main
       with:
         android: true
@@ -45,9 +46,15 @@ jobs:
       run: make buildServer
 
     - name: Set up QEMU
+      if: ${{ github.event.inputs.build_multiarch == 'true' }}
       uses: docker/setup-qemu-action@v2
 
     - name: Set up Docker Buildx
+      if: ${{ github.event.inputs.build_multiarch == 'false' }}
+      uses: docker/setup-buildx-action@v2
+
+    - name: Set up Docker Buildx
+      if: ${{ github.event.inputs.build_multiarch == 'true' }}
       uses: docker/setup-buildx-action@v2
       with:
         config-inline: |

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -14,6 +14,7 @@ on:
   workflow_call:
     inputs:
       build_multiarch:
+        default: 'false'
         required: true
         type: boolean
 

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,5 +1,11 @@
 name: CI
 
+inputs:
+  build_multiarch:
+    default: 'false'
+    required: true
+    type: boolean
+
 on:
   push:
     paths-ignore:
@@ -12,11 +18,6 @@ on:
     branches:
       - '*'
   workflow_call:
-    inputs:
-      build_multiarch:
-        default: 'false'
-        required: true
-        type: boolean
 
 jobs:
   test-containers:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -40,6 +40,10 @@ jobs:
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2
+      with:
+        config-inline: |
+          [worker.oci]
+            max-parallelism = 2
 
     - name: Cache Docker layers
       uses: actions/cache@v3

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -11,6 +11,11 @@ on:
       - 'docs/**'
     branches:
       - '*'
+  workflow_call:
+    inputs:
+      build_multiarch:
+        required: true
+        type: boolean
 
 jobs:
   test-containers:
@@ -47,6 +52,7 @@ jobs:
     - name: Build container images
       run: make buildDockerImages
       env:
+        BUILD_MULTIARCH: ${{ inputs.build_multiarch }}
         CACHE_FROM: 'type=local,src=/tmp/.buildx-cache'
         CACHE_TO: 'type=local,dest=/tmp/.buildx-cache-new'
 

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -22,6 +22,15 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3
+    
+    - name: Free up disk space
+      uses: jlumbroso/free-disk-space@main
+      with:
+        android: true
+        dotnet: true
+        haskell: true
+        large-packages: true
+        swap-storage: true
 
     - name: Set up JDK 11
       uses: actions/setup-java@v3

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -1,0 +1,11 @@
+name: CI (nightly)
+
+on:
+  schedule:
+    - cron: '0 2 * * *'
+
+jobs:
+  test-containers-multiarch:
+    uses: ./.github/workflows/main
+    with:
+      build_multiarch: true

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -6,6 +6,6 @@ on:
 
 jobs:
   test-containers-multiarch:
-    uses: ./.github/workflows/main
+    uses: ./.github/workflows/main.yaml
     with:
       build_multiarch: true

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,9 @@ endif
 buildDockerImages:
 ifdef BUILD_MULTIARCH
 	docker buildx bake kroki --set "*.cache-from=$(CACHE_FROM)" --set "*.cache-to=$(CACHE_TO)" --set "*.platform=linux/arm64,linux/amd64"
+	docker image prune --force
 	docker buildx bake companion-images --set "*.cache-from=$(CACHE_FROM)" --set "*.cache-to=$(CACHE_TO)" --set "*.platform=linux/arm64,linux/amd64"
+	docker image prune --force
 else
 	docker buildx bake kroki --set "*.cache-from=$(CACHE_FROM)" --set "*.cache-to=$(CACHE_TO)" --set "*.platform=linux/arm64,linux/amd64"
 	docker buildx bake companion-images --set "*.cache-from=$(CACHE_FROM)" --set "*.cache-to=$(CACHE_TO)" --set "*.platform=linux/arm64,linux/amd64"

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,3 @@
-MULTI_ARCH_AVAILABLE := $(shell docker buildx inspect | grep amd64 | grep arm64 > /dev/null 2>&1; echo $$?)
-
 TESTS_DIR=ci/tests
 COMPOSE_TIMEOUT=20
 SERVICES_TIMEOUT=15
@@ -19,11 +17,7 @@ endif
 	mvn versions:set -DnewVersion=$(RELEASE_VERSION)
 
 buildDockerImages:
-ifeq ($(MULTI_ARCH_AVAILABLE), 0)
-	docker buildx bake --set "*.cache-from=$(CACHE_FROM)" --set "*.cache-to=$(CACHE_TO)" --set "*.platform=linux/arm64,linux/amd64"
-else
 	docker buildx bake --set "*.cache-from=$(CACHE_FROM)" --set "*.cache-to=$(CACHE_TO)"
-endif
 
 publishDockerImages:
 ifndef RELEASE_VERSION

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ endif
 
 buildDockerImages:
 ifeq ($(MULTI_ARCH_AVAILABLE), 0)
-	docker buildx bake --set "*.cache-from=$(CACHE_FROM)" --set "*.cache-to=$(CACHE_TO)" --set "*.platform=linux/arm64"
+	docker buildx bake --set "*.cache-from=$(CACHE_FROM)" --set "*.cache-to=$(CACHE_TO)" --set "*.platform=linux/arm64,linux/amd64"
 else
 	docker buildx bake --set "*.cache-from=$(CACHE_FROM)" --set "*.cache-to=$(CACHE_TO)"
 endif

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ endif
 
 buildDockerImages:
 ifeq ($(MULTI_ARCH_AVAILABLE), 0)
-	docker buildx bake --set "*.cache-from=$(CACHE_FROM)" --set "*.cache-to=$(CACHE_TO)" --set "kroki-*.platform=linux/arm64,linux/amd64"
+	docker buildx bake --set "*.cache-from=$(CACHE_FROM)" --set "*.cache-to=$(CACHE_TO)" --set "*.platform=linux/arm64,linux/amd64"
 else
 	docker buildx bake --set "*.cache-from=$(CACHE_FROM)" --set "*.cache-to=$(CACHE_TO)"
 endif
@@ -29,7 +29,7 @@ publishDockerImages:
 ifndef RELEASE_VERSION
 	$(error RELEASE_VERSION is undefined)
 endif
-	docker buildx bake -f docker-bake.hcl -f docker-bake-release.hcl --push --set "kroki-*.platform=linux/arm64,linux/amd64"
+	docker buildx bake -f docker-bake.hcl -f docker-bake-release.hcl --push --set "*.platform=linux/arm64,linux/amd64"
 
 smokeTests:
 	TAG=smoketests docker buildx bake --load --set "*.cache-from=$(CACHE_FROM)" --set "*.cache-to=$(CACHE_TO)"

--- a/Makefile
+++ b/Makefile
@@ -19,9 +19,7 @@ endif
 buildDockerImages:
 ifdef BUILD_MULTIARCH
 	docker buildx bake kroki --set "*.cache-from=$(CACHE_FROM)" --set "*.cache-to=$(CACHE_TO)" --set "*.platform=linux/arm64,linux/amd64"
-	docker image prune --force
 	docker buildx bake companion-images --set "*.cache-from=$(CACHE_FROM)" --set "*.cache-to=$(CACHE_TO)" --set "*.platform=linux/arm64,linux/amd64"
-	docker image prune --force
 else
 	docker buildx bake kroki --set "*.cache-from=$(CACHE_FROM)" --set "*.cache-to=$(CACHE_TO)" --set "*.platform=linux/arm64,linux/amd64"
 	docker buildx bake companion-images --set "*.cache-from=$(CACHE_FROM)" --set "*.cache-to=$(CACHE_TO)" --set "*.platform=linux/arm64,linux/amd64"

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ endif
 	docker buildx bake -f docker-bake.hcl -f docker-bake-release.hcl companion-images --push --set "*.platform=linux/arm64,linux/amd64"
 
 smokeTests:
-	TAG=smoketests docker buildx bake --load --set "*.cache-from=$(CACHE_FROM)" --set "*.cache-to=$(CACHE_TO)"
+	TAG=smoketests docker buildx bake kroki companion-images --load --set "*.cache-from=$(CACHE_FROM)" --set "*.cache-to=$(CACHE_TO)"
 	@docker-compose --file "$(TESTS_DIR)/docker-compose.yaml" up --build --detach \
 	&& echo \
 	&& docker-compose --file "$(TESTS_DIR)/docker-compose.yaml" ps \

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,8 @@ ifdef BUILD_MULTIARCH
 	docker buildx bake kroki --set "*.cache-from=$(CACHE_FROM)" --set "*.cache-to=$(CACHE_TO)" --set "*.platform=linux/arm64,linux/amd64"
 	docker buildx bake companion-images --set "*.cache-from=$(CACHE_FROM)" --set "*.cache-to=$(CACHE_TO)" --set "*.platform=linux/arm64,linux/amd64"
 else
-	docker buildx bake kroki companion-images --set "*.cache-from=$(CACHE_FROM)" --set "*.cache-to=$(CACHE_TO)"
+	docker buildx bake kroki --set "*.cache-from=$(CACHE_FROM)" --set "*.cache-to=$(CACHE_TO)" --set "*.platform=linux/arm64,linux/amd64"
+	docker buildx bake companion-images --set "*.cache-from=$(CACHE_FROM)" --set "*.cache-to=$(CACHE_TO)" --set "*.platform=linux/arm64,linux/amd64"
 endif
 
 publishDockerImages:

--- a/Makefile
+++ b/Makefile
@@ -18,19 +18,16 @@ endif
 
 buildDockerImages:
 ifdef BUILD_MULTIARCH
-	docker buildx bake kroki --set "*.cache-from=$(CACHE_FROM)" --set "*.cache-to=$(CACHE_TO)" --set "*.platform=linux/arm64,linux/amd64"
-	docker buildx bake companion-images --set "*.cache-from=$(CACHE_FROM)" --set "*.cache-to=$(CACHE_TO)" --set "*.platform=linux/arm64,linux/amd64"
+	docker buildx bake kroki companion-images --set "*.cache-from=$(CACHE_FROM)" --set "*.cache-to=$(CACHE_TO)" --set "*.platform=linux/arm64,linux/amd64"
 else
-	docker buildx bake kroki --set "*.cache-from=$(CACHE_FROM)" --set "*.cache-to=$(CACHE_TO)" --set "*.platform=linux/arm64,linux/amd64"
-	docker buildx bake companion-images --set "*.cache-from=$(CACHE_FROM)" --set "*.cache-to=$(CACHE_TO)" --set "*.platform=linux/arm64,linux/amd64"
+	docker buildx bake kroki companion-images --set "*.cache-from=$(CACHE_FROM)" --set "*.cache-to=$(CACHE_TO)" --set "*.platform=linux/arm64,linux/amd64"
 endif
 
 publishDockerImages:
 ifndef RELEASE_VERSION
 	$(error RELEASE_VERSION is undefined)
 endif
-	docker buildx bake -f docker-bake.hcl -f docker-bake-release.hcl kroki --push --set "*.platform=linux/arm64,linux/amd64"
-	docker buildx bake -f docker-bake.hcl -f docker-bake-release.hcl companion-images --push --set "*.platform=linux/arm64,linux/amd64"
+	docker buildx bake -f docker-bake.hcl -f docker-bake-release.hcl kroki companion-images --push --set "*.platform=linux/arm64,linux/amd64"
 
 smokeTests:
 	TAG=smoketests docker buildx bake kroki companion-images --load --set "*.cache-from=$(CACHE_FROM)" --set "*.cache-to=$(CACHE_TO)"

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ buildDockerImages:
 ifdef BUILD_MULTIARCH
 	docker buildx bake kroki companion-images --set "*.cache-from=$(CACHE_FROM)" --set "*.cache-to=$(CACHE_TO)" --set "*.platform=linux/arm64,linux/amd64"
 else
-	docker buildx bake kroki companion-images --set "*.cache-from=$(CACHE_FROM)" --set "*.cache-to=$(CACHE_TO)" --set "*.platform=linux/arm64,linux/amd64"
+	docker buildx bake kroki companion-images --set "*.cache-from=$(CACHE_FROM)" --set "*.cache-to=$(CACHE_TO)"
 endif
 
 publishDockerImages:

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ endif
 
 buildDockerImages:
 ifeq ($(MULTI_ARCH_AVAILABLE), 0)
-	docker buildx bake --set "*.cache-from=$(CACHE_FROM)" --set "*.cache-to=$(CACHE_TO)" --set "*.platform=linux/arm64,linux/amd64"
+	docker buildx bake --set "*.cache-from=$(CACHE_FROM)" --set "*.cache-to=$(CACHE_TO)" --set "*.platform=linux/arm64"
 else
 	docker buildx bake --set "*.cache-from=$(CACHE_FROM)" --set "*.cache-to=$(CACHE_TO)"
 endif

--- a/bpmn/Dockerfile
+++ b/bpmn/Dockerfile
@@ -1,5 +1,5 @@
 # Package the Node.js project into a single binary
-FROM node:16.18.1-alpine3.16 as builder
+FROM --platform=$BUILDPLATFORM node:16.18.1-alpine3.16 as builder
 
 # Workaround: https://github.com/nodejs/docker-node/issues/813#issuecomment-407339011
 # Error: could not get uid/gid
@@ -10,7 +10,7 @@ RUN npm install -g pkg@5.6.0 pkg-fetch@3.3.0
 
 ENV NODE node16
 ENV PLATFORM alpine
-RUN /usr/local/bin/pkg-fetch -n ${NODE} -p ${PLATFORM}
+RUN /usr/local/bin/pkg-fetch -n ${NODE} -p ${PLATFORM} -a $([ "$TARGETARCH" == "amd64" ] && echo "x64" || echo "$TARGETARCH")
 
 COPY package.json package-lock.json /app/
 COPY src /app/src
@@ -19,7 +19,7 @@ WORKDIR /app
 RUN PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=1 npm ci
 RUN npm run lint
 
-RUN /usr/local/bin/pkg --targets ${NODE}-${PLATFORM} . -o app.bin
+RUN /usr/local/bin/pkg --targets ${NODE}-${PLATFORM}-$([ "$TARGETARCH" == "amd64" ] && echo "x64" || echo "$TARGETARCH") . -o app.bin
 
 # Create the image
 FROM alpine:3.16.3

--- a/bpmn/Dockerfile
+++ b/bpmn/Dockerfile
@@ -1,5 +1,5 @@
 # Package the Node.js project into a single binary
-FROM --platform=${TARGETPLATFORM:-linux/amd64} node:16.18.1-alpine3.16 as builder
+FROM node:16.18.1-alpine3.16 as builder
 
 # Workaround: https://github.com/nodejs/docker-node/issues/813#issuecomment-407339011
 # Error: could not get uid/gid
@@ -10,7 +10,7 @@ RUN npm install -g pkg@5.6.0 pkg-fetch@3.3.0
 
 ENV NODE node16
 ENV PLATFORM alpine
-RUN /usr/local/bin/pkg-fetch -n ${NODE} -p ${PLATFORM} -a $([ "$TARGETARCH" == "amd64" ] && echo "x64" || echo "$TARGETARCH")
+RUN /usr/local/bin/pkg-fetch -n ${NODE} -p ${PLATFORM}
 
 COPY package.json package-lock.json /app/
 COPY src /app/src
@@ -19,10 +19,10 @@ WORKDIR /app
 RUN PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=1 npm ci
 RUN npm run lint
 
-RUN /usr/local/bin/pkg --targets ${NODE}-${PLATFORM}-$([ "$TARGETARCH" == "amd64" ] && echo "x64" || echo "$TARGETARCH") . -o app.bin
+RUN /usr/local/bin/pkg --targets ${NODE}-${PLATFORM} . -o app.bin
 
 # Create the image
-FROM --platform=${TARGETPLATFORM:-linux/amd64} alpine:3.16.3
+FROM alpine:3.16.3
 
 RUN addgroup -g 1000 kroki && adduser -D -G kroki -u 1000 kroki
 

--- a/diagrams.net/Dockerfile
+++ b/diagrams.net/Dockerfile
@@ -1,5 +1,5 @@
 # Package the Node.js project into a single binary
-FROM node:16.18.1-alpine3.16 as builder
+FROM --platform=$BUILDPLATFORM node:16.18.1-alpine3.16 as builder
 
 # Workaround: https://github.com/nodejs/docker-node/issues/813#issuecomment-407339011
 # Error: could not get uid/gid
@@ -10,7 +10,7 @@ RUN npm install -g pkg@5.6.0 pkg-fetch@3.3.0
 
 ENV NODE node16
 ENV PLATFORM alpine
-RUN /usr/local/bin/pkg-fetch -n ${NODE} -p ${PLATFORM}
+RUN /usr/local/bin/pkg-fetch -n ${NODE} -p ${PLATFORM} -a $([ "$TARGETARCH" == "amd64" ] && echo "x64" || echo "$TARGETARCH")
 
 COPY package.json package-lock.json /app/
 COPY src /app/src
@@ -19,7 +19,7 @@ WORKDIR /app
 RUN PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=1 npm ci
 RUN npm run lint
 
-RUN /usr/local/bin/pkg --targets ${NODE}-${PLATFORM} . -o app.bin
+RUN /usr/local/bin/pkg --targets ${NODE}-${PLATFORM}-$([ "$TARGETARCH" == "amd64" ] && echo "x64" || echo "$TARGETARCH") . -o app.bin
 
 # Create the image
 FROM alpine:3.16.3

--- a/diagrams.net/Dockerfile
+++ b/diagrams.net/Dockerfile
@@ -1,5 +1,5 @@
 # Package the Node.js project into a single binary
-FROM --platform=${TARGETPLATFORM:-linux/amd64} node:16.18.1-alpine3.16 as builder
+FROM node:16.18.1-alpine3.16 as builder
 
 # Workaround: https://github.com/nodejs/docker-node/issues/813#issuecomment-407339011
 # Error: could not get uid/gid
@@ -10,7 +10,7 @@ RUN npm install -g pkg@5.6.0 pkg-fetch@3.3.0
 
 ENV NODE node16
 ENV PLATFORM alpine
-RUN /usr/local/bin/pkg-fetch -n ${NODE} -p ${PLATFORM} -a $([ "$TARGETARCH" == "amd64" ] && echo "x64" || echo "$TARGETARCH")
+RUN /usr/local/bin/pkg-fetch -n ${NODE} -p ${PLATFORM}
 
 COPY package.json package-lock.json /app/
 COPY src /app/src
@@ -19,10 +19,10 @@ WORKDIR /app
 RUN PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=1 npm ci
 RUN npm run lint
 
-RUN /usr/local/bin/pkg --targets ${NODE}-${PLATFORM}-$([ "$TARGETARCH" == "amd64" ] && echo "x64" || echo "$TARGETARCH") . -o app.bin
+RUN /usr/local/bin/pkg --targets ${NODE}-${PLATFORM} . -o app.bin
 
 # Create the image
-FROM --platform=${TARGETPLATFORM:-linux/amd64} alpine:3.16.3
+FROM alpine:3.16.3
 
 RUN addgroup -g 1000 kroki && adduser -D -G kroki -u 1000 kroki
 

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -2,8 +2,8 @@ variable "TAG" {
   default = "latest"
 }
 
-group "default" {
-  targets = ["kroki", "kroki-blockdiag", "kroki-mermaid", "kroki-bpmn", "kroki-excalidraw", "kroki-diagramsnet", "kroki-wireviz"]
+group "companion-images" {
+  targets = ["kroki-blockdiag", "kroki-mermaid", "kroki-bpmn", "kroki-excalidraw", "kroki-diagramsnet", "kroki-wireviz"]
 }
 
 target "kroki" {

--- a/excalidraw/Dockerfile
+++ b/excalidraw/Dockerfile
@@ -1,5 +1,5 @@
 # Package the Node.js project into a single binary
-FROM node:16.18.1-alpine3.16 as builder
+FROM --platform=$BUILDPLATFORM node:16.18.1-alpine3.16 as builder
 
 # Workaround: https://github.com/nodejs/docker-node/issues/813#issuecomment-407339011
 # Error: could not get uid/gid
@@ -10,7 +10,7 @@ RUN npm install -g pkg@5.6.0 pkg-fetch@3.3.0
 
 ENV NODE node16
 ENV PLATFORM alpine
-RUN /usr/local/bin/pkg-fetch -n ${NODE} -p ${PLATFORM}
+RUN /usr/local/bin/pkg-fetch -n ${NODE} -p ${PLATFORM} -a $([ "$TARGETARCH" == "amd64" ] && echo "x64" || echo "$TARGETARCH")
 
 COPY package.json package-lock.json /app/
 COPY src /app/src
@@ -21,7 +21,7 @@ RUN PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=1 npm ci
 RUN npm run lint
 RUN npm run prestart
 
-RUN /usr/local/bin/pkg --targets ${NODE}-${PLATFORM} . -o app.bin
+RUN /usr/local/bin/pkg --targets ${NODE}-${PLATFORM}-$([ "$TARGETARCH" == "amd64" ] && echo "x64" || echo "$TARGETARCH") . -o app.bin
 
 # Create the image
 FROM alpine:3.16.3

--- a/excalidraw/Dockerfile
+++ b/excalidraw/Dockerfile
@@ -1,5 +1,5 @@
 # Package the Node.js project into a single binary
-FROM --platform=${TARGETPLATFORM:-linux/amd64} node:16.18.1-alpine3.16 as builder
+FROM node:16.18.1-alpine3.16 as builder
 
 # Workaround: https://github.com/nodejs/docker-node/issues/813#issuecomment-407339011
 # Error: could not get uid/gid
@@ -10,7 +10,7 @@ RUN npm install -g pkg@5.6.0 pkg-fetch@3.3.0
 
 ENV NODE node16
 ENV PLATFORM alpine
-RUN /usr/local/bin/pkg-fetch -n ${NODE} -p ${PLATFORM} -a $([ "$TARGETARCH" == "amd64" ] && echo "x64" || echo "$TARGETARCH")
+RUN /usr/local/bin/pkg-fetch -n ${NODE} -p ${PLATFORM}
 
 COPY package.json package-lock.json /app/
 COPY src /app/src
@@ -21,10 +21,10 @@ RUN PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=1 npm ci
 RUN npm run lint
 RUN npm run prestart
 
-RUN /usr/local/bin/pkg --targets ${NODE}-${PLATFORM}-$([ "$TARGETARCH" == "amd64" ] && echo "x64" || echo "$TARGETARCH") . -o app.bin
+RUN /usr/local/bin/pkg --targets ${NODE}-${PLATFORM} . -o app.bin
 
 # Create the image
-FROM --platform=${TARGETPLATFORM:-linux/amd64} alpine:3.16.3
+FROM alpine:3.16.3
 
 RUN addgroup -g 1000 kroki && adduser -D -G kroki -u 1000 kroki
 

--- a/mermaid/Dockerfile
+++ b/mermaid/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=${TARGETPLATFORM:-linux/amd64} node:16.18-alpine3.16
+FROM node:16.18-alpine3.16
 
 RUN addgroup -g 1001 kroki && adduser -D -G kroki -u 1001 kroki
 

--- a/server/ops/docker/.cargo/config
+++ b/server/ops/docker/.cargo/config
@@ -1,0 +1,5 @@
+[target.aarch64-unknown-linux-gnu]
+linker = "aarch64-linux-gnu-gcc"
+
+[target.x86_64-unknown-linux-gnu]
+linker = "x86_64-linux-gnu-gcc"

--- a/server/ops/docker/jdk11-jammy/Dockerfile
+++ b/server/ops/docker/jdk11-jammy/Dockerfile
@@ -170,7 +170,7 @@ RUN wget -q "https://pikchr.org/home/raw/${PIKCHR_VERSION}" -O pikchr.c
 RUN gcc -O0 -g -static -Wall -Wextra -DPIKCHR_SHELL pikchr.c -o pikchr -lm
 
 ## SVGBob
-FROM rust:1.65-slim-bullseye AS kroki-builder-static-svgbob
+FROM rust:1.68-slim-bullseye AS kroki-builder-static-svgbob
 
 ARG TARGETARCH
 
@@ -179,7 +179,7 @@ COPY ops/docker/Cargo.toml .
 RUN case ${TARGETARCH} in "amd64") RUST_TARGETARCH=x86_64 ;; "arm64") RUST_TARGETARCH=aarch64 ;; esac && \
     rustup target add ${RUST_TARGETARCH}-unknown-linux-musl && \
     SVGBOB_VERSION=`cat Cargo.toml | grep "svgbob_cli =" | sed -r 's/.*"([^"]+)"/\1/'` && \
-    cargo install --quiet --target ${RUST_TARGETARCH}-unknown-linux-musl --version $SVGBOB_VERSION svgbob_cli
+    cargo install --quiet -Z sparse-registry --target ${RUST_TARGETARCH}-unknown-linux-musl --version $SVGBOB_VERSION svgbob_cli
 
 ## UMlet
 # use a pre-built image to reduce build time

--- a/server/ops/docker/jdk11-jammy/Dockerfile
+++ b/server/ops/docker/jdk11-jammy/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1.4
 
 ## TikZ
-FROM ubuntu:jammy AS kroki-builder-dvisvgm
+FROM --platform=$BUILDPLATFORM ubuntu:jammy AS kroki-builder-dvisvgm
 
 RUN apt-get update && apt-get install --no-install-recommends --yes \
     build-essential \
@@ -17,39 +17,50 @@ RUN apt-get update && apt-get install --no-install-recommends --yes \
 
 ARG DVISVGM_VERSION=3.0.4
 
-RUN \
-    curl -LO https://github.com/mgieseki/dvisvgm/releases/download/$DVISVGM_VERSION/dvisvgm-$DVISVGM_VERSION.tar.gz \
-    && tar xf dvisvgm-$DVISVGM_VERSION.tar.gz \
-    && cd dvisvgm-$DVISVGM_VERSION \
-    && ./configure --enable-bundled-libs \
-    && make \
-    && make install
+ARG BUILDARCH
+ARG TARGETARCH
+RUN curl -LO https://github.com/mgieseki/dvisvgm/releases/download/$DVISVGM_VERSION/dvisvgm-$DVISVGM_VERSION.tar.gz && \
+    tar xf dvisvgm-$DVISVGM_VERSION.tar.gz && \
+    cd dvisvgm-$DVISVGM_VERSION && \
+    case $BUILDARCH in \
+        "amd64") MAKE_BUILD_ARCH=x86_64 ;; \
+        "arm64") MAKE_BUILD_ARCH=aarch64 ;; \
+        *) MAKE_BUILD_ARCH=$TARGETARCH ;; \
+    esac && \
+    case $TARGETARCH in \
+        "amd64") MAKE_TARGET_ARCH=x86_64 ;; \
+        "arm64") MAKE_TARGET_ARCH=aarch64 ;; \
+        *) MAKE_TARGET_ARCH=$TARGETARCH ;; \
+    esac && \
+    ./configure --enable-bundled-libs --build $MAKE_BUILD_ARCH-linux-gnu --host $MAKE_TARGET_ARCH-linux-gnu && \
+    make && \
+    make install
 
 ## D2
 FROM golang:1.19.3-bullseye AS kroki-builder-d2
 COPY ops/docker/go.mod .
 
-RUN D2_VERSION=`cat go.mod | grep "oss.terrastruct.com/d2" | cut -d' ' -f3` \
-  && rm go.mod \
-  && go install "oss.terrastruct.com/d2@${D2_VERSION}"
+RUN D2_VERSION=`cat go.mod | grep "oss.terrastruct.com/d2" | cut -d' ' -f3` && \
+    rm go.mod && \
+    go install "oss.terrastruct.com/d2@${D2_VERSION}"
 
 ## Nomnoml
-FROM node:16.18.1-bullseye-slim AS kroki-builder-nomnoml
+FROM --platform=$BUILDPLATFORM node:16.18.1-bullseye-slim AS kroki-builder-nomnoml
 
 RUN npm install -g pkg@5.6.0 pkg-fetch@3.3.0
 
 ENV NODE node16
 ENV PLATFORM linux
-RUN /usr/local/bin/pkg-fetch -n ${NODE} -p ${PLATFORM}
+RUN /usr/local/bin/pkg-fetch -n ${NODE} -p ${PLATFORM} -a $([ "$TARGETARCH" == "amd64" ] && echo "x64" || echo "$TARGETARCH")
 
 COPY --from=nomnoml index.js package.json package-lock.json /app/
 WORKDIR /app
 
 RUN npm install && npm run lint
-RUN /usr/local/bin/pkg --targets ${NODE}-${PLATFORM} . -o app.bin
+RUN /usr/local/bin/pkg --targets ${NODE}-${PLATFORM}-$([ "$TARGETARCH" == "amd64" ] && echo "x64" || echo "$TARGETARCH") . -o app.bin
 
 ## Vega
-FROM node:16.18.1-bullseye-slim AS kroki-builder-vega
+FROM --platform=$BUILDPLATFORM node:16.18.1-bullseye-slim AS kroki-builder-vega
 
 # System dependencies for "canvas" Node package
 # https://github.com/Automattic/node-canvas#compiling
@@ -66,7 +77,7 @@ RUN npm install -g pkg@5.6.0 pkg-fetch@3.3.0
 
 ENV NODE node16
 ENV PLATFORM linux
-RUN /usr/local/bin/pkg-fetch -n ${NODE} -p ${PLATFORM}
+RUN /usr/local/bin/pkg-fetch -n ${NODE} -p ${PLATFORM} -a $([ "$TARGETARCH" == "amd64" ] && echo "x64" || echo "$TARGETARCH")
 
 COPY --from=vega src /app/src
 COPY --from=vega tests /app/tests
@@ -74,10 +85,10 @@ COPY --from=vega package.json package-lock.json /app/
 WORKDIR /app
 
 RUN npm install 2 && npm run lint && npm t
-RUN /usr/local/bin/pkg --targets ${NODE}-${PLATFORM} . -o app.bin
+RUN /usr/local/bin/pkg --targets ${NODE}-${PLATFORM}-$([ "$TARGETARCH" == "amd64" ] && echo "x64" || echo "$TARGETARCH") . -o app.bin
 
 ## DBML
-FROM node:16.18.1-bullseye-slim AS kroki-builder-dbml
+FROM --platform=$BUILDPLATFORM node:16.18.1-bullseye-slim AS kroki-builder-dbml
 
 RUN npm config set unsafe-perm true
 
@@ -85,43 +96,43 @@ RUN npm install -g pkg@5.6.0 pkg-fetch@3.3.0
 
 ENV NODE node16
 ENV PLATFORM linux
-RUN /usr/local/bin/pkg-fetch -n ${NODE} -p ${PLATFORM}
+RUN /usr/local/bin/pkg-fetch -n ${NODE} -p ${PLATFORM} -a $([ "$TARGETARCH" == "amd64" ] && echo "x64" || echo "$TARGETARCH")
 
 COPY --from=dbml index.js package.json package-lock.json /app/
 WORKDIR /app
 
 RUN npm install && npm run lint
-RUN /usr/local/bin/pkg --targets ${NODE}-${PLATFORM} . -o app.bin
+RUN /usr/local/bin/pkg --targets ${NODE}-${PLATFORM}-$([ "$TARGETARCH" == "amd64" ] && echo "x64" || echo "$TARGETARCH") . -o app.bin
 
 ## Wavedrom
-FROM node:16.18.1-bullseye-slim AS kroki-builder-wavedrom
+FROM --platform=$BUILDPLATFORM node:16.18.1-bullseye-slim AS kroki-builder-wavedrom
 
 RUN npm install -g pkg@5.6.0 pkg-fetch@3.3.0
 
 ENV NODE node16
 ENV PLATFORM linux
-RUN /usr/local/bin/pkg-fetch -n ${NODE} -p ${PLATFORM}
+RUN /usr/local/bin/pkg-fetch -n ${NODE} -p ${PLATFORM} -a $([ "$TARGETARCH" == "amd64" ] && echo "x64" || echo "$TARGETARCH")
 
 COPY --from=wavedrom index.js package.json package-lock.json /app/
 WORKDIR /app
 
 RUN npm install && npm run lint
-RUN /usr/local/bin/pkg --targets ${NODE}-${PLATFORM} . -o app.bin
+RUN /usr/local/bin/pkg --targets ${NODE}-${PLATFORM}-$([ "$TARGETARCH" == "amd64" ] && echo "x64" || echo "$TARGETARCH") . -o app.bin
 
 ## Bytefield
-FROM node:16.18.1-bullseye-slim AS kroki-builder-bytefield
+FROM --platform=$BUILDPLATFORM node:16.18.1-bullseye-slim AS kroki-builder-bytefield
 
 RUN npm install -g pkg@5.6.0 pkg-fetch@3.3.0
 
 ENV NODE node16
 ENV PLATFORM linux
-RUN /usr/local/bin/pkg-fetch -n ${NODE} -p ${PLATFORM}
+RUN /usr/local/bin/pkg-fetch -n ${NODE} -p ${PLATFORM} -a $([ "$TARGETARCH" == "amd64" ] && echo "x64" || echo "$TARGETARCH")
 
 COPY --from=bytefield index.js package.json package-lock.json /app/
 WORKDIR /app
 
 RUN npm install
-RUN /usr/local/bin/pkg --targets ${NODE}-${PLATFORM} . -o app.bin
+RUN /usr/local/bin/pkg --targets ${NODE}-${PLATFORM}-$([ "$TARGETARCH" == "amd64" ] && echo "x64" || echo "$TARGETARCH") . -o app.bin
 
 ## ERD
 # use a pre-built image to reduce build time
@@ -166,13 +177,29 @@ RUN wget -q "https://pikchr.org/home/raw/${PIKCHR_VERSION}" -O pikchr.c
 RUN gcc -O0 -g -static -Wall -Wextra -DPIKCHR_SHELL pikchr.c -o pikchr -lm
 
 ## SVGBob
-FROM rust:1.68-slim-bullseye AS kroki-builder-static-svgbob
+FROM --platform=$BUILDPLATFORM rust:1.68-slim-bullseye AS kroki-builder-static-svgbob
+
+# Install cross-compilation tools
+RUN apt-get update && apt-get install --no-install-recommends --yes \
+    gcc-aarch64-linux-gnu \
+    gcc-x86-64-linux-gnu \
+    libc6-dev-amd64-cross \
+    libc6-dev-arm64-cross && \
+    apt-get clean && apt-get autoremove
 
 COPY ops/docker/Cargo.toml .
+COPY ops/docker/.cargo .cargo
 
+ARG TARGETARCH
 ENV CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
 RUN SVGBOB_VERSION=`cat Cargo.toml | grep "svgbob_cli =" | sed -r 's/.*"([^"]+)"/\1/'` && \
-    cargo install --quiet --version $SVGBOB_VERSION svgbob_cli
+    case $TARGETARCH in \
+        "amd64") RUST_TARGET_ARCH=x86_64 ;; \
+        "arm64") RUST_TARGET_ARCH=aarch64 ;; \
+        *) RUST_TARGET_ARCH=$TARGETARCH ;; \
+    esac && \
+    rustup target add $RUST_TARGET_ARCH-unknown-linux-gnu && \
+    cargo install --quiet --target $RUST_TARGET_ARCH-unknown-linux-gnu --version $SVGBOB_VERSION svgbob_cli
 
 ## UMlet
 # use a pre-built image to reduce build time
@@ -223,7 +250,8 @@ RUN apt-get update && apt-get install --no-install-recommends --yes \
     texlive-latex-extra \
     texlive-pictures \
     texlive-pstricks \
-    texlive-science
+    texlive-science && \
+    apt-get clean && apt-get autoremove
 
 COPY --chown=kroki:kroki ops/docker/logback.xml /etc/kroki/logback.xml
 

--- a/server/ops/docker/jdk11-jammy/Dockerfile
+++ b/server/ops/docker/jdk11-jammy/Dockerfile
@@ -36,7 +36,7 @@ RUN D2_VERSION=`cat go.mod | grep "oss.terrastruct.com/d2" | cut -d' ' -f3` \
 ## Nomnoml
 FROM node:16.18.1-bullseye-slim AS kroki-builder-nomnoml
 
-RUN npm install -g pkg@5.6.0 pkg-fetch@3.3.0
+RUN npm install -g pkg@5.6.0 pkg-fetch@3.3.0 --maxsockets 2
 
 ENV NODE node16
 ENV PLATFORM linux
@@ -45,7 +45,7 @@ RUN /usr/local/bin/pkg-fetch -n ${NODE} -p ${PLATFORM}
 COPY --from=nomnoml index.js package.json package-lock.json /app/
 WORKDIR /app
 
-RUN npm install && npm run lint
+RUN npm install --maxsockets 2 && npm run lint
 RUN /usr/local/bin/pkg --targets ${NODE}-${PLATFORM} . -o app.bin
 
 ## Vega
@@ -62,7 +62,7 @@ RUN apt-get update && apt-get install --no-install-recommends --yes \
     librsvg2-dev && \
     apt-get clean && apt-get autoremove
 
-RUN npm install -g pkg@5.6.0 pkg-fetch@3.3.0
+RUN npm install -g pkg@5.6.0 pkg-fetch@3.3.0 --maxsockets 2
 
 ENV NODE node16
 ENV PLATFORM linux
@@ -73,7 +73,7 @@ COPY --from=vega tests /app/tests
 COPY --from=vega package.json package-lock.json /app/
 WORKDIR /app
 
-RUN npm install && npm run lint && npm t
+RUN npm install --maxsockets 2 && npm run lint && npm t
 RUN /usr/local/bin/pkg --targets ${NODE}-${PLATFORM} . -o app.bin
 
 ## DBML
@@ -90,13 +90,13 @@ RUN /usr/local/bin/pkg-fetch -n ${NODE} -p ${PLATFORM}
 COPY --from=dbml index.js package.json package-lock.json /app/
 WORKDIR /app
 
-RUN npm install && npm run lint
+RUN npm install --maxsockets 2 && npm run lint
 RUN /usr/local/bin/pkg --targets ${NODE}-${PLATFORM} . -o app.bin
 
 ## Wavedrom
 FROM node:16.18.1-bullseye-slim AS kroki-builder-wavedrom
 
-RUN npm install -g pkg@5.6.0 pkg-fetch@3.3.0
+RUN npm install -g pkg@5.6.0 pkg-fetch@3.3.0 --maxsockets 2
 
 ENV NODE node16
 ENV PLATFORM linux
@@ -105,13 +105,13 @@ RUN /usr/local/bin/pkg-fetch -n ${NODE} -p ${PLATFORM}
 COPY --from=wavedrom index.js package.json package-lock.json /app/
 WORKDIR /app
 
-RUN npm install && npm run lint
+RUN npm install --maxsockets 2 && npm run lint
 RUN /usr/local/bin/pkg --targets ${NODE}-${PLATFORM} . -o app.bin
 
 ## Bytefield
 FROM node:16.18.1-bullseye-slim AS kroki-builder-bytefield
 
-RUN npm install -g pkg@5.6.0 pkg-fetch@3.3.0
+RUN npm install -g pkg@5.6.0 pkg-fetch@3.3.0 --maxsockets 2
 
 ENV NODE node16
 ENV PLATFORM linux
@@ -120,7 +120,7 @@ RUN /usr/local/bin/pkg-fetch -n ${NODE} -p ${PLATFORM}
 COPY --from=bytefield index.js package.json package-lock.json /app/
 WORKDIR /app
 
-RUN npm install
+RUN npm install --maxsockets 2
 RUN /usr/local/bin/pkg --targets ${NODE}-${PLATFORM} . -o app.bin
 
 ## ERD

--- a/server/ops/docker/jdk11-jammy/Dockerfile
+++ b/server/ops/docker/jdk11-jammy/Dockerfile
@@ -36,7 +36,7 @@ RUN D2_VERSION=`cat go.mod | grep "oss.terrastruct.com/d2" | cut -d' ' -f3` \
 ## Nomnoml
 FROM node:16.18.1-bullseye-slim AS kroki-builder-nomnoml
 
-RUN npm install -g pkg@5.6.0 pkg-fetch@3.3.0 --maxsockets 2
+RUN npm install -g pkg@5.6.0 pkg-fetch@3.3.0
 
 ENV NODE node16
 ENV PLATFORM linux
@@ -45,7 +45,7 @@ RUN /usr/local/bin/pkg-fetch -n ${NODE} -p ${PLATFORM}
 COPY --from=nomnoml index.js package.json package-lock.json /app/
 WORKDIR /app
 
-RUN npm install --maxsockets 2 && npm run lint
+RUN npm install && npm run lint
 RUN /usr/local/bin/pkg --targets ${NODE}-${PLATFORM} . -o app.bin
 
 ## Vega
@@ -62,7 +62,7 @@ RUN apt-get update && apt-get install --no-install-recommends --yes \
     librsvg2-dev && \
     apt-get clean && apt-get autoremove
 
-RUN npm install -g pkg@5.6.0 pkg-fetch@3.3.0 --maxsockets 2
+RUN npm install -g pkg@5.6.0 pkg-fetch@3.3.0
 
 ENV NODE node16
 ENV PLATFORM linux
@@ -73,7 +73,7 @@ COPY --from=vega tests /app/tests
 COPY --from=vega package.json package-lock.json /app/
 WORKDIR /app
 
-RUN npm install --maxsockets 2 && npm run lint && npm t
+RUN npm install 2 && npm run lint && npm t
 RUN /usr/local/bin/pkg --targets ${NODE}-${PLATFORM} . -o app.bin
 
 ## DBML
@@ -90,13 +90,13 @@ RUN /usr/local/bin/pkg-fetch -n ${NODE} -p ${PLATFORM}
 COPY --from=dbml index.js package.json package-lock.json /app/
 WORKDIR /app
 
-RUN npm install --maxsockets 2 && npm run lint
+RUN npm install && npm run lint
 RUN /usr/local/bin/pkg --targets ${NODE}-${PLATFORM} . -o app.bin
 
 ## Wavedrom
 FROM node:16.18.1-bullseye-slim AS kroki-builder-wavedrom
 
-RUN npm install -g pkg@5.6.0 pkg-fetch@3.3.0 --maxsockets 2
+RUN npm install -g pkg@5.6.0 pkg-fetch@3.3.0
 
 ENV NODE node16
 ENV PLATFORM linux
@@ -105,13 +105,13 @@ RUN /usr/local/bin/pkg-fetch -n ${NODE} -p ${PLATFORM}
 COPY --from=wavedrom index.js package.json package-lock.json /app/
 WORKDIR /app
 
-RUN npm install --maxsockets 2 && npm run lint
+RUN npm install && npm run lint
 RUN /usr/local/bin/pkg --targets ${NODE}-${PLATFORM} . -o app.bin
 
 ## Bytefield
 FROM node:16.18.1-bullseye-slim AS kroki-builder-bytefield
 
-RUN npm install -g pkg@5.6.0 pkg-fetch@3.3.0 --maxsockets 2
+RUN npm install -g pkg@5.6.0 pkg-fetch@3.3.0
 
 ENV NODE node16
 ENV PLATFORM linux
@@ -120,7 +120,7 @@ RUN /usr/local/bin/pkg-fetch -n ${NODE} -p ${PLATFORM}
 COPY --from=bytefield index.js package.json package-lock.json /app/
 WORKDIR /app
 
-RUN npm install --maxsockets 2
+RUN npm install
 RUN /usr/local/bin/pkg --targets ${NODE}-${PLATFORM} . -o app.bin
 
 ## ERD
@@ -167,8 +167,6 @@ RUN gcc -O0 -g -static -Wall -Wextra -DPIKCHR_SHELL pikchr.c -o pikchr -lm
 
 ## SVGBob
 FROM rust:1.68-slim-bullseye AS kroki-builder-static-svgbob
-
-ARG TARGETARCH
 
 COPY ops/docker/Cargo.toml .
 

--- a/server/ops/docker/jdk11-jammy/Dockerfile
+++ b/server/ops/docker/jdk11-jammy/Dockerfile
@@ -45,8 +45,7 @@ RUN /usr/local/bin/pkg-fetch -n ${NODE} -p ${PLATFORM}
 COPY --from=nomnoml index.js package.json package-lock.json /app/
 WORKDIR /app
 
-RUN npm i
-RUN npm run lint
+RUN npm install --maxsockets 1 && npm run lint
 RUN /usr/local/bin/pkg --targets ${NODE}-${PLATFORM} . -o app.bin
 
 ## Vega
@@ -74,8 +73,7 @@ COPY --from=vega tests /app/tests
 COPY --from=vega package.json package-lock.json /app/
 WORKDIR /app
 
-RUN npm i
-RUN npm run lint && npm t
+RUN npm install --maxsockets 1 && npm run lint && npm t
 RUN /usr/local/bin/pkg --targets ${NODE}-${PLATFORM} . -o app.bin
 
 ## DBML
@@ -92,8 +90,7 @@ RUN /usr/local/bin/pkg-fetch -n ${NODE} -p ${PLATFORM}
 COPY --from=dbml index.js package.json package-lock.json /app/
 WORKDIR /app
 
-RUN npm i
-RUN npm run lint
+RUN npm install --maxsockets 1 && npm run lint
 RUN /usr/local/bin/pkg --targets ${NODE}-${PLATFORM} . -o app.bin
 
 ## Wavedrom
@@ -108,8 +105,7 @@ RUN /usr/local/bin/pkg-fetch -n ${NODE} -p ${PLATFORM}
 COPY --from=wavedrom index.js package.json package-lock.json /app/
 WORKDIR /app
 
-RUN npm i
-RUN npm run lint
+RUN npm install --maxsockets 1 && npm run lint
 RUN /usr/local/bin/pkg --targets ${NODE}-${PLATFORM} . -o app.bin
 
 ## Bytefield
@@ -124,7 +120,7 @@ RUN /usr/local/bin/pkg-fetch -n ${NODE} -p ${PLATFORM}
 COPY --from=bytefield index.js package.json package-lock.json /app/
 WORKDIR /app
 
-RUN npm i
+RUN npm install --maxsockets 1
 RUN /usr/local/bin/pkg --targets ${NODE}-${PLATFORM} . -o app.bin
 
 ## ERD

--- a/server/ops/docker/jdk11-jammy/Dockerfile
+++ b/server/ops/docker/jdk11-jammy/Dockerfile
@@ -176,10 +176,9 @@ ARG TARGETARCH
 
 COPY ops/docker/Cargo.toml .
 
-RUN case ${TARGETARCH} in "amd64") RUST_TARGETARCH=x86_64 ;; "arm64") RUST_TARGETARCH=aarch64 ;; esac && \
-    rustup target add ${RUST_TARGETARCH}-unknown-linux-musl && \
-    SVGBOB_VERSION=`cat Cargo.toml | grep "svgbob_cli =" | sed -r 's/.*"([^"]+)"/\1/'` && \
-    cargo install --quiet -Z sparse-registry --target ${RUST_TARGETARCH}-unknown-linux-musl --version $SVGBOB_VERSION svgbob_cli
+ENV CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
+RUN SVGBOB_VERSION=`cat Cargo.toml | grep "svgbob_cli =" | sed -r 's/.*"([^"]+)"/\1/'` && \
+    cargo install --quiet --version $SVGBOB_VERSION svgbob_cli
 
 ## UMlet
 # use a pre-built image to reduce build time

--- a/server/ops/docker/jdk11-jammy/Dockerfile
+++ b/server/ops/docker/jdk11-jammy/Dockerfile
@@ -178,7 +178,7 @@ COPY ops/docker/Cargo.toml .
 
 RUN case ${TARGETARCH} in \
          "amd64")  RUST_TARGETARCH=x86_64 ;; \
-         "arm64")  RUST_TARGETARCH=arm64  ;; \
+         "arm64")  RUST_TARGETARCH=aarch64 ;; \
     esac && \
     rustup target add $RUST_TARGETARCH-unknown-linux-musl && \
     SVGBOB_VERSION=`cat Cargo.toml | grep "svgbob_cli =" | sed -r 's/.*"([^"]+)"/\1/'` && \

--- a/server/ops/docker/jdk11-jammy/Dockerfile
+++ b/server/ops/docker/jdk11-jammy/Dockerfile
@@ -45,7 +45,7 @@ RUN /usr/local/bin/pkg-fetch -n ${NODE} -p ${PLATFORM}
 COPY --from=nomnoml index.js package.json package-lock.json /app/
 WORKDIR /app
 
-RUN npm install --maxsockets 1 && npm run lint
+RUN npm install && npm run lint
 RUN /usr/local/bin/pkg --targets ${NODE}-${PLATFORM} . -o app.bin
 
 ## Vega
@@ -73,7 +73,7 @@ COPY --from=vega tests /app/tests
 COPY --from=vega package.json package-lock.json /app/
 WORKDIR /app
 
-RUN npm install --maxsockets 1 && npm run lint && npm t
+RUN npm install && npm run lint && npm t
 RUN /usr/local/bin/pkg --targets ${NODE}-${PLATFORM} . -o app.bin
 
 ## DBML
@@ -90,7 +90,7 @@ RUN /usr/local/bin/pkg-fetch -n ${NODE} -p ${PLATFORM}
 COPY --from=dbml index.js package.json package-lock.json /app/
 WORKDIR /app
 
-RUN npm install --maxsockets 1 && npm run lint
+RUN npm install && npm run lint
 RUN /usr/local/bin/pkg --targets ${NODE}-${PLATFORM} . -o app.bin
 
 ## Wavedrom
@@ -105,7 +105,7 @@ RUN /usr/local/bin/pkg-fetch -n ${NODE} -p ${PLATFORM}
 COPY --from=wavedrom index.js package.json package-lock.json /app/
 WORKDIR /app
 
-RUN npm install --maxsockets 1 && npm run lint
+RUN npm install && npm run lint
 RUN /usr/local/bin/pkg --targets ${NODE}-${PLATFORM} . -o app.bin
 
 ## Bytefield
@@ -120,7 +120,7 @@ RUN /usr/local/bin/pkg-fetch -n ${NODE} -p ${PLATFORM}
 COPY --from=bytefield index.js package.json package-lock.json /app/
 WORKDIR /app
 
-RUN npm install --maxsockets 1
+RUN npm install
 RUN /usr/local/bin/pkg --targets ${NODE}-${PLATFORM} . -o app.bin
 
 ## ERD

--- a/server/ops/docker/jdk11-jammy/Dockerfile
+++ b/server/ops/docker/jdk11-jammy/Dockerfile
@@ -171,11 +171,18 @@ RUN gcc -O0 -g -static -Wall -Wextra -DPIKCHR_SHELL pikchr.c -o pikchr -lm
 
 ## SVGBob
 FROM rust:1.65-slim-bullseye AS kroki-builder-static-svgbob
-RUN rustup target add x86_64-unknown-linux-musl
+
+ARG TARGETARCH
+
 COPY ops/docker/Cargo.toml .
 
-RUN SVGBOB_VERSION=`cat Cargo.toml | grep "svgbob_cli =" | sed -r 's/.*"([^"]+)"/\1/'` \
-  && cargo install --quiet --target x86_64-unknown-linux-musl --version $SVGBOB_VERSION svgbob_cli
+RUN case ${TARGETARCH} in \
+         "amd64")  RUST_TARGETARCH=x86_64 ;; \
+         "arm64")  RUST_TARGETARCH=arm64  ;; \
+    esac && \
+    rustup target add $RUST_TARGETARCH-unknown-linux-musl && \
+    SVGBOB_VERSION=`cat Cargo.toml | grep "svgbob_cli =" | sed -r 's/.*"([^"]+)"/\1/'` && \
+    cargo install --quiet --target $RUST_TARGETARCH-unknown-linux-musl --version $SVGBOB_VERSION svgbob_cli
 
 ## UMlet
 # use a pre-built image to reduce build time

--- a/server/ops/docker/jdk11-jammy/Dockerfile
+++ b/server/ops/docker/jdk11-jammy/Dockerfile
@@ -176,13 +176,10 @@ ARG TARGETARCH
 
 COPY ops/docker/Cargo.toml .
 
-RUN case ${TARGETARCH} in \
-         "amd64")  RUST_TARGETARCH=x86_64 ;; \
-         "arm64")  RUST_TARGETARCH=aarch64 ;; \
-    esac && \
-    rustup target add $RUST_TARGETARCH-unknown-linux-musl && \
+RUN case ${TARGETARCH} in "amd64") RUST_TARGETARCH=x86_64 ;; "arm64") RUST_TARGETARCH=aarch64 ;; esac && \
+    rustup target add ${RUST_TARGETARCH}-unknown-linux-musl && \
     SVGBOB_VERSION=`cat Cargo.toml | grep "svgbob_cli =" | sed -r 's/.*"([^"]+)"/\1/'` && \
-    cargo install --quiet --target $RUST_TARGETARCH-unknown-linux-musl --version $SVGBOB_VERSION svgbob_cli
+    cargo install --quiet --target ${RUST_TARGETARCH}-unknown-linux-musl --version $SVGBOB_VERSION svgbob_cli
 
 ## UMlet
 # use a pre-built image to reduce build time

--- a/server/src/test/java/io/kroki/server/service/VegaServiceTest.java
+++ b/server/src/test/java/io/kroki/server/service/VegaServiceTest.java
@@ -33,8 +33,8 @@ public class VegaServiceTest {
       assertThat(buffer.toString()).isEqualTo("<svg>vega</svg>");
       testContext.completeNow();
     })));
-    // wait at most 2000ms
-    assertThat(testContext.awaitCompletion(2, TimeUnit.SECONDS)).isTrue();
+    // wait at most 4000ms
+    assertThat(testContext.awaitCompletion(4, TimeUnit.SECONDS)).isTrue();
     if (testContext.failed()) {
       throw testContext.causeOfFailure();
     }
@@ -55,8 +55,8 @@ public class VegaServiceTest {
       assertThat(buffer.toString()).isEqualTo("<svg>vega-lite</svg>");
       testContext.completeNow();
     })));
-    // wait at most 2000ms
-    assertThat(testContext.awaitCompletion(2, TimeUnit.SECONDS)).isTrue();
+    // wait at most 4000ms
+    assertThat(testContext.awaitCompletion(4, TimeUnit.SECONDS)).isTrue();
     if (testContext.failed()) {
       throw testContext.causeOfFailure();
     }

--- a/vega/tests/test.js
+++ b/vega/tests/test.js
@@ -12,6 +12,7 @@ chai.use(dirtyChai)
 const { convert } = require('../src/convert.js')
 
 describe('#convert', function () {
+  this.timeout(15000)
   it('should throw UnsafeIncludeError in secure mode when the Vega-Lite specification contains data.url', async function () {
     const input = `{
   "data": {"url": "data/cars.json"},


### PR DESCRIPTION
Builds an `arm64` variant of the main Kroki Docker image by leveraging the changes introduced in #1476. All images should now natively support the ARM architecture. This includes the following changes:

- Creates a `nightly` workflow to build the multi-arch images every night at 02:00 UTC.
- Restricts the Docker Buildx builder to 2 parallel threads. This matches the 2 cores available on the GitHub CI runners and prevents timeouts during the build process.
- Runs a [free disk space](https://github.com/jlumbroso/free-disk-space) action at the start of the CI workflow to recover extra disk space from the CI runner. This is now necessary to successfully complete the build process.