### PR TITLE
Documentation: complete available themes for d2 diagrams

### DIFF
--- a/docs/modules/setup/pages/diagram-options.adoc
+++ b/docs/modules/setup/pages/diagram-options.adoc
@@ -58,8 +58,11 @@ With flag set, option takes effect.
 * `earth-tones` (`103`)
 * `everglade-green` (`104`)
 * `buttered-toast` (`105`)
+* `dark-mauve` (`200`)
+* `terminal` (`300`)
+* `terminal-grayscale` (`301`)
 
-| See: https://github.com/terrastruct/d2/blob/master/docs/assets/themes_overview.png
+| See: https://d2lang.com/tour/themes/
 |===
 
 == GraphViz

--- a/server/src/main/java/io/kroki/server/service/D2.java
+++ b/server/src/main/java/io/kroki/server/service/D2.java
@@ -41,7 +41,10 @@ public class D2 implements DiagramService {
     entry("shirley-temple", 102),
     entry("earth-tones", 103),
     entry("everglade-green", 104),
-    entry("buttered-toast", 105)
+    entry("buttered-toast", 105),
+    entry("dark-mauve", 200),
+    entry("terminal", 300),
+    entry("terminal-grayscale", 301)
   );
 
   public D2(Vertx vertx, JsonObject config, Commander commander) {


### PR DESCRIPTION
This PR adds further themes available for d2 diagrams to the documentation.
Were great if the docs could be redeployed after merge so that changes take effect.