### PR TITLE
Allow SSL certificate to be passed as a file path

### DIFF
--- a/docs/modules/setup/pages/configuration.adoc
+++ b/docs/modules/setup/pages/configuration.adoc
@@ -271,4 +271,4 @@ podman run -p8000:8000 -e KROKI_SSL=true --env-file=.env yuzutech/kroki
 
 ====
 
-If SSL is enabled, both `KROKI_SSL_KEY` / `KROKI_SSL_KEY_PATH` and `KROKI_SSL_CERT` / `KROKI_SSL_CERT_PATH` must be configured.
+If SSL is enabled, both `KROKI_SSL_KEY` (or `KROKI_SSL_KEY_PATH`) and `KROKI_SSL_CERT` (or `KROKI_SSL_CERT_PATH`) must be configured.

--- a/docs/modules/setup/pages/configuration.adoc
+++ b/docs/modules/setup/pages/configuration.adoc
@@ -215,7 +215,23 @@ We recommend to use a maximum length that's not greater than 8192 and not greate
 
 By default, SSL/TLS is not enabled on the server but you can enable it by setting `KROKI_SSL` environment variable to `true`.
 
-When SSL is enabled, you must provide the certificate and the private key values as PEM format using `KROKI_SSL_KEY` and `KROKI_SSL_CERT` environment variables.
+When SSL is enabled, you must provide the certificate and the private key in one of two ways:
+
+- As strings in PEM format using the `KROKI_SSL_KEY` and `KROKI_SSL_CERT` environment variables, e.g.,:
++
+[source,bash]
+----
+KROKI_SSL_KEY="-----BEGIN RSA PRIVATE KEY-----<PRIVATE_KEY>-----END RSA PRIVATE KEY-----"
+----
+
+- As PEM file paths using the `KROKI_SSL_KEY_PATH` and `KROKI_SSL_CERT_PATH` environment variables.
++
+[source,bash]
+----
+KROKI_SSL_KEY_PATH="/etc/ssl/certs/mydomain/privatekey.pem"
+----
+
+If both methods are used, the values in `KROKI_SSL_KEY` and `KROKI_SSL_CERT` are given priority.
 
 [NOTE]
 ====
@@ -255,5 +271,4 @@ podman run -p8000:8000 -e KROKI_SSL=true --env-file=.env yuzutech/kroki
 
 ====
 
-If SSL is enabled, both `KROKI_SSL_KEY` and `KROKI_SSL_CERT` must be configured.
-
+If SSL is enabled, both `KROKI_SSL_KEY` / `KROKI_SSL_KEY_PATH` and `KROKI_SSL_CERT` / `KROKI_SSL_CERT_PATH` must be configured.

--- a/server/src/main/java/io/kroki/server/Server.java
+++ b/server/src/main/java/io/kroki/server/Server.java
@@ -49,10 +49,6 @@ import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.handler.BodyHandler;
 import io.vertx.ext.web.handler.CorsHandler;
 
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -182,48 +178,27 @@ public class Server extends AbstractVerticle {
 
   private static void setPemKeyCertOptions(JsonObject config, HttpServerOptions serverOptions, boolean enableSSL) {
     if (enableSSL) {
-      Optional<String> sslKeyValue;
-      Optional<String> sslCertValue;
-
       if (!config.containsKey("KROKI_SSL_KEY") && !config.containsKey("KROKI_SSL_KEY_PATH")) {
         throw new IllegalArgumentException("KROKI_SSL_KEY or KROKI_SSL_KEY_PATH must be configured when SSL is enabled.");
       }
       else if (!config.getString("KROKI_SSL_KEY").isEmpty()) {
-        // Get the key from KROKI_SSL_KEY as a string
-        sslKeyValue = Optional.ofNullable(config.getString("KROKI_SSL_KEY"));
+        Optional<String> sslKeyValue = Optional.ofNullable(config.getString("KROKI_SSL_KEY"));
+        serverOptions.setPemKeyCertOptions(new PemKeyCertOptions().addKeyValue(Buffer.buffer(sslKeyValue.get())));
       }
       else {
-        // Read the key from the file given by KROKI_SSL_KEY_PATH
-        try {
-          sslKeyValue = Optional.ofNullable(Files.readString(Paths.get(config.getString("KROKI_SSL_KEY_PATH"))));
-        }
-        catch (IOException e) {
-          throw new IllegalArgumentException("An error occurred while reading the key given by KROKI_SSL_KEY_PATH.");
-        }
+        serverOptions.setPemKeyCertOptions(new PemKeyCertOptions().addKeyPath(config.getString("KROKI_SSL_KEY_PATH")));
       }
 
       if (!config.containsKey("KROKI_SSL_CERT") && !config.containsKey("KROKI_SSL_CERT_PATH")) {
         throw new IllegalArgumentException("KROKI_SSL_CERT or KROKI_SSL_CERT_PATH must be configured when SSL is enabled.");
       }
       else if (!config.getString("KROKI_SSL_CERT").isEmpty()) {
-        // Get the key from KROKI_SSL_CERT as a string
-        sslCertValue = Optional.ofNullable(config.getString("KROKI_SSL_CERT"));
+        Optional<String> sslCertValue = Optional.ofNullable(config.getString("KROKI_SSL_CERT"));
+        serverOptions.setPemKeyCertOptions(new PemKeyCertOptions().addCertValue(Buffer.buffer(sslCertValue.get())));
       }
       else {
-        // Read the key from the file given by KROKI_SSL_CERT_PATH
-        try {
-          sslCertValue = Optional.ofNullable(Files.readString(Paths.get(config.getString("KROKI_SSL_CERT_PATH"))));
-        }
-        catch (IOException e) {
-          throw new IllegalArgumentException("An error occurred while reading the key given by KROKI_SSL_CERT_PATH.");
-        }
+        serverOptions.setPemKeyCertOptions(new PemKeyCertOptions().addCertPath(config.getString("KROKI_SSL_CERT_PATH")));
       }
-
-      serverOptions.setPemKeyCertOptions(
-        new PemKeyCertOptions()
-          .addKeyValue(Buffer.buffer(sslKeyValue.get()))
-          .addCertValue(Buffer.buffer(sslCertValue.get()))
-      );
     }
   }
 

--- a/server/src/main/java/io/kroki/server/Server.java
+++ b/server/src/main/java/io/kroki/server/Server.java
@@ -179,21 +179,26 @@ public class Server extends AbstractVerticle {
   private static void setPemKeyCertOptions(JsonObject config, HttpServerOptions serverOptions, boolean enableSSL) {
     if (enableSSL) {
       PemKeyCertOptions certOptions = new PemKeyCertOptions();
+      Optional<String> sslKeyValue = Optional.ofNullable(config.getString("KROKI_SSL_KEY"));
+      Optional<String> sslKeyPath = Optional.ofNullable(config.getString("KROKI_SSL_KEY_PATH"));
+      Optional<String> sslCertValue = Optional.ofNullable(config.getString("KROKI_SSL_CERT"));
+      Optional<String> sslCertPath = Optional.ofNullable(config.getString("KROKI_SSL_CERT_PATH"));
 
-      if (!config.containsKey("KROKI_SSL_KEY") && !config.containsKey("KROKI_SSL_KEY_PATH")) {
+      if (sslKeyValue.isEmpty() && sslKeyPath.isEmpty()) {
         throw new IllegalArgumentException("KROKI_SSL_KEY or KROKI_SSL_KEY_PATH must be configured when SSL is enabled.");
       }
-      else if (config.containsKey("KROKI_SSL_KEY") && !config.getString("KROKI_SSL_KEY").isEmpty()) {
+      if (sslCertValue.isEmpty() && sslCertPath.isEmpty()) {
+        throw new IllegalArgumentException("KROKI_SSL_CERT or KROKI_SSL_CERT_PATH must be configured when SSL is enabled.");
+      }
+
+      if (sslKeyValue.isPresent() {
         certOptions.addKeyValue(Buffer.buffer(config.getString("KROKI_SSL_KEY")));
       }
       else {
         certOptions.addKeyPath(config.getString("KROKI_SSL_KEY_PATH"));
       }
 
-      if (!config.containsKey("KROKI_SSL_CERT") && !config.containsKey("KROKI_SSL_CERT_PATH")) {
-        throw new IllegalArgumentException("KROKI_SSL_CERT or KROKI_SSL_CERT_PATH must be configured when SSL is enabled.");
-      }
-      else if (config.containsKey("KROKI_SSL_CERT") && !config.getString("KROKI_SSL_CERT").isEmpty()) {
+      if (sslCertValue.isPresent()) {
         certOptions.addCertValue(Buffer.buffer(config.getString("KROKI_SSL_CERT")));
       }
       else {

--- a/server/src/main/java/io/kroki/server/Server.java
+++ b/server/src/main/java/io/kroki/server/Server.java
@@ -178,27 +178,29 @@ public class Server extends AbstractVerticle {
 
   private static void setPemKeyCertOptions(JsonObject config, HttpServerOptions serverOptions, boolean enableSSL) {
     if (enableSSL) {
+      PemKeyCertOptions certOptions = new PemKeyCertOptions();
+
       if (!config.containsKey("KROKI_SSL_KEY") && !config.containsKey("KROKI_SSL_KEY_PATH")) {
         throw new IllegalArgumentException("KROKI_SSL_KEY or KROKI_SSL_KEY_PATH must be configured when SSL is enabled.");
       }
       else if (!config.getString("KROKI_SSL_KEY").isEmpty()) {
-        Optional<String> sslKeyValue = Optional.ofNullable(config.getString("KROKI_SSL_KEY"));
-        serverOptions.setPemKeyCertOptions(new PemKeyCertOptions().addKeyValue(Buffer.buffer(sslKeyValue.get())));
+        certOptions.addKeyValue(Buffer.buffer(config.getString("KROKI_SSL_KEY")));
       }
       else {
-        serverOptions.setPemKeyCertOptions(new PemKeyCertOptions().addKeyPath(config.getString("KROKI_SSL_KEY_PATH")));
+        certOptions.addKeyPath(config.getString("KROKI_SSL_KEY_PATH"));
       }
 
       if (!config.containsKey("KROKI_SSL_CERT") && !config.containsKey("KROKI_SSL_CERT_PATH")) {
         throw new IllegalArgumentException("KROKI_SSL_CERT or KROKI_SSL_CERT_PATH must be configured when SSL is enabled.");
       }
       else if (!config.getString("KROKI_SSL_CERT").isEmpty()) {
-        Optional<String> sslCertValue = Optional.ofNullable(config.getString("KROKI_SSL_CERT"));
-        serverOptions.setPemKeyCertOptions(new PemKeyCertOptions().addCertValue(Buffer.buffer(sslCertValue.get())));
+        certOptions.addCertValue(Buffer.buffer(config.getString("KROKI_SSL_CERT")));
       }
       else {
-        serverOptions.setPemKeyCertOptions(new PemKeyCertOptions().addCertPath(config.getString("KROKI_SSL_CERT_PATH")));
+        certOptions.addCertPath(config.getString("KROKI_SSL_CERT_PATH"));
       }
+
+      serverOptions.setPemKeyCertOptions(certOptions);
     }
   }
 

--- a/server/src/main/java/io/kroki/server/Server.java
+++ b/server/src/main/java/io/kroki/server/Server.java
@@ -49,6 +49,10 @@ import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.handler.BodyHandler;
 import io.vertx.ext.web.handler.CorsHandler;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -178,11 +182,43 @@ public class Server extends AbstractVerticle {
 
   private static void setPemKeyCertOptions(JsonObject config, HttpServerOptions serverOptions, boolean enableSSL) {
     if (enableSSL) {
-      Optional<String> sslKeyValue = Optional.ofNullable(config.getString("KROKI_SSL_KEY"));
-      Optional<String> sslCertValue = Optional.ofNullable(config.getString("KROKI_SSL_CERT"));
-      if (sslKeyValue.isEmpty() || sslCertValue.isEmpty()) {
-        throw new IllegalArgumentException("KROKI_SSL_KEY and KROKI_SSL_CERT must be configured when SSL is enabled.");
+      Optional<String> sslKeyValue;
+      Optional<String> sslCertValue;
+
+      if (!config.containsKey("KROKI_SSL_KEY") && !config.containsKey("KROKI_SSL_KEY_PATH")) {
+        throw new IllegalArgumentException("KROKI_SSL_KEY or KROKI_SSL_KEY_PATH must be configured when SSL is enabled.");
       }
+      else if (!config.getString("KROKI_SSL_KEY").isEmpty()) {
+        // Get the key from KROKI_SSL_KEY as a string
+        sslKeyValue = Optional.ofNullable(config.getString("KROKI_SSL_KEY"));
+      }
+      else {
+        // Read the key from the file given by KROKI_SSL_KEY_PATH
+        try {
+          sslKeyValue = Optional.ofNullable(Files.readString(Paths.get(config.getString("KROKI_SSL_KEY_PATH"))));
+        }
+        catch (IOException e) {
+          throw new IllegalArgumentException("An error occurred while reading the key given by KROKI_SSL_KEY_PATH.");
+        }
+      }
+
+      if (!config.containsKey("KROKI_SSL_CERT") && !config.containsKey("KROKI_SSL_CERT_PATH")) {
+        throw new IllegalArgumentException("KROKI_SSL_CERT or KROKI_SSL_CERT_PATH must be configured when SSL is enabled.");
+      }
+      else if (!config.getString("KROKI_SSL_CERT").isEmpty()) {
+        // Get the key from KROKI_SSL_CERT as a string
+        sslCertValue = Optional.ofNullable(config.getString("KROKI_SSL_CERT"));
+      }
+      else {
+        // Read the key from the file given by KROKI_SSL_CERT_PATH
+        try {
+          sslCertValue = Optional.ofNullable(Files.readString(Paths.get(config.getString("KROKI_SSL_CERT_PATH"))));
+        }
+        catch (IOException e) {
+          throw new IllegalArgumentException("An error occurred while reading the key given by KROKI_SSL_CERT_PATH.");
+        }
+      }
+
       serverOptions.setPemKeyCertOptions(
         new PemKeyCertOptions()
           .addKeyValue(Buffer.buffer(sslKeyValue.get()))

--- a/server/src/main/java/io/kroki/server/Server.java
+++ b/server/src/main/java/io/kroki/server/Server.java
@@ -183,7 +183,7 @@ public class Server extends AbstractVerticle {
       if (!config.containsKey("KROKI_SSL_KEY") && !config.containsKey("KROKI_SSL_KEY_PATH")) {
         throw new IllegalArgumentException("KROKI_SSL_KEY or KROKI_SSL_KEY_PATH must be configured when SSL is enabled.");
       }
-      else if (!config.getString("KROKI_SSL_KEY").isEmpty()) {
+      else if (config.containsKey("KROKI_SSL_KEY") && !config.getString("KROKI_SSL_KEY").isEmpty()) {
         certOptions.addKeyValue(Buffer.buffer(config.getString("KROKI_SSL_KEY")));
       }
       else {
@@ -193,7 +193,7 @@ public class Server extends AbstractVerticle {
       if (!config.containsKey("KROKI_SSL_CERT") && !config.containsKey("KROKI_SSL_CERT_PATH")) {
         throw new IllegalArgumentException("KROKI_SSL_CERT or KROKI_SSL_CERT_PATH must be configured when SSL is enabled.");
       }
-      else if (!config.getString("KROKI_SSL_CERT").isEmpty()) {
+      else if (config.containsKey("KROKI_SSL_CERT") && !config.getString("KROKI_SSL_CERT").isEmpty()) {
         certOptions.addCertValue(Buffer.buffer(config.getString("KROKI_SSL_CERT")));
       }
       else {

--- a/server/src/main/java/io/kroki/server/Server.java
+++ b/server/src/main/java/io/kroki/server/Server.java
@@ -191,7 +191,7 @@ public class Server extends AbstractVerticle {
         throw new IllegalArgumentException("KROKI_SSL_CERT or KROKI_SSL_CERT_PATH must be configured when SSL is enabled.");
       }
 
-      if (sslKeyValue.isPresent() {
+      if (sslKeyValue.isPresent()) {
         certOptions.addKeyValue(Buffer.buffer(config.getString("KROKI_SSL_KEY")));
       }
       else {

--- a/server/src/test/java/io/kroki/server/ServerSSLTest.java
+++ b/server/src/test/java/io/kroki/server/ServerSSLTest.java
@@ -55,7 +55,7 @@ class ServerSSLTest {
   }
 
   @Test
-  void with_ssl_enabled_using_string_and_secure_http_web_client(Vertx vertx, VertxTestContext testContext) {
+  void with_ssl_enabled_by_string_and_secure_http_web_client(Vertx vertx, VertxTestContext testContext) {
     Handler<AsyncResult<String>> handle = deployVerticleResult -> {
       // successful deployment
       testContext.verify(() -> assertThat(deployVerticleResult.failed()).isFalse());
@@ -72,11 +72,11 @@ class ServerSSLTest {
           testContext.completeNow();
         })));
     };
-    vertx.deployVerticle(new Server(), new DeploymentOptions().setConfig(configWithSslEnabledUsingString(vertx)), handle);
+    vertx.deployVerticle(new Server(), new DeploymentOptions().setConfig(configWithSslEnabledByString(vertx)), handle);
   }
 
   @Test
-  void with_ssl_enabled__using_path_and_secure_http_web_client(Vertx vertx, VertxTestContext testContext) {
+  void with_ssl_enabled_by_path_and_secure_http_web_client(Vertx vertx, VertxTestContext testContext) {
     Handler<AsyncResult<String>> handle = deployVerticleResult -> {
       // successful deployment
       testContext.verify(() -> assertThat(deployVerticleResult.failed()).isFalse());
@@ -93,11 +93,11 @@ class ServerSSLTest {
           testContext.completeNow();
         })));
     };
-    vertx.deployVerticle(new Server(), new DeploymentOptions().setConfig(configWithSslEnabledUsingPath(vertx)), handle);
+    vertx.deployVerticle(new Server(), new DeploymentOptions().setConfig(configWithSslEnabledByPath(vertx)), handle);
   }
 
   @Test
-  void with_ssl_enabled_using_string_and_insecure_http_web_client(Vertx vertx, VertxTestContext testContext) {
+  void with_ssl_enabled_by_string_and_insecure_http_web_client(Vertx vertx, VertxTestContext testContext) {
     Handler<AsyncResult<String>> handle = deployVerticleResult -> {
       // successful deployment
       testContext.verify(() -> assertThat(deployVerticleResult.failed()).isFalse());
@@ -108,11 +108,11 @@ class ServerSSLTest {
         .as(BodyCodec.string())
         .send(testContext.failing(response -> testContext.verify(testContext::completeNow)));
     };
-    vertx.deployVerticle(new Server(), new DeploymentOptions().setConfig(configWithSslEnabledUsingString(vertx)), handle);
+    vertx.deployVerticle(new Server(), new DeploymentOptions().setConfig(configWithSslEnabledByString(vertx)), handle);
   }
 
   @Test
-  void with_ssl_enabled_using_path_and_insecure_http_web_client(Vertx vertx, VertxTestContext testContext) {
+  void with_ssl_enabled_by_path_and_insecure_http_web_client(Vertx vertx, VertxTestContext testContext) {
     Handler<AsyncResult<String>> handle = deployVerticleResult -> {
       // successful deployment
       testContext.verify(() -> assertThat(deployVerticleResult.failed()).isFalse());
@@ -123,17 +123,17 @@ class ServerSSLTest {
         .as(BodyCodec.string())
         .send(testContext.failing(response -> testContext.verify(testContext::completeNow)));
     };
-    vertx.deployVerticle(new Server(), new DeploymentOptions().setConfig(configWithSslEnabledUsingPath(vertx)), handle);
+    vertx.deployVerticle(new Server(), new DeploymentOptions().setConfig(configWithSslEnabledByPath(vertx)), handle);
   }
 
   @Test
-  void with_ssl_enabled_using_string_and_missing_ssl_key_config(Vertx vertx, VertxTestContext testContext) {
+  void with_ssl_enabled_by_string_and_missing_ssl_key_config(Vertx vertx, VertxTestContext testContext) {
     Handler<AsyncResult<String>> handle = deployVerticleResult -> {
       // failed deployment
       testContext.verify(() -> {
         assertThat(deployVerticleResult.failed()).isTrue();
         assertThat(deployVerticleResult.cause()).isInstanceOf(IllegalArgumentException.class);
-        assertThat(deployVerticleResult.cause()).hasMessage("KROKI_SSL_KEY and KROKI_SSL_CERT or KROKI_SSL_KEY_PATH and KROKI_SSL_CERT_PATH must be configured when SSL is enabled.");
+        assertThat(deployVerticleResult.cause()).hasMessage("KROKI_SSL_KEY or KROKI_SSL_KEY_PATH must be configured when SSL is enabled.");
       });
       WebClientOptions options = new WebClientOptions();
       options.setSsl(true);
@@ -145,17 +145,17 @@ class ServerSSLTest {
         .as(BodyCodec.string())
         .send(testContext.failing(response -> testContext.verify(testContext::completeNow)));
     };
-    vertx.deployVerticle(new Server(), new DeploymentOptions().setConfig(configWithSslEnabledUsingStringMissingKey(vertx)), handle);
+    vertx.deployVerticle(new Server(), new DeploymentOptions().setConfig(configWithSslEnabledByStringMissingKey(vertx)), handle);
   }
 
   @Test
-  void with_ssl_enabled_using_path_and_missing_ssl_key_config(Vertx vertx, VertxTestContext testContext) {
+  void with_ssl_enabled_by_path_and_missing_ssl_key_config(Vertx vertx, VertxTestContext testContext) {
     Handler<AsyncResult<String>> handle = deployVerticleResult -> {
       // failed deployment
       testContext.verify(() -> {
         assertThat(deployVerticleResult.failed()).isTrue();
         assertThat(deployVerticleResult.cause()).isInstanceOf(IllegalArgumentException.class);
-        assertThat(deployVerticleResult.cause()).hasMessage("KROKI_SSL_KEY and KROKI_SSL_CERT or KROKI_SSL_KEY_PATH and KROKI_SSL_CERT_PATH must be configured when SSL is enabled.");
+        assertThat(deployVerticleResult.cause()).hasMessage("KROKI_SSL_KEY or KROKI_SSL_KEY_PATH must be configured when SSL is enabled.");
       });
       WebClientOptions options = new WebClientOptions();
       options.setSsl(true);
@@ -167,7 +167,7 @@ class ServerSSLTest {
         .as(BodyCodec.string())
         .send(testContext.failing(response -> testContext.verify(testContext::completeNow)));
     };
-    vertx.deployVerticle(new Server(), new DeploymentOptions().setConfig(configWithSslEnabledUsingPathMissingKey(vertx)), handle);
+    vertx.deployVerticle(new Server(), new DeploymentOptions().setConfig(configWithSslEnabledByPathMissingKey(vertx)), handle);
   }
 
   private JsonObject configWithSslDisabled() {
@@ -176,13 +176,13 @@ class ServerSSLTest {
       .put("KROKI_SSL", false);
   }
 
-  private JsonObject configWithSslEnabledUsingStringMissingKey(Vertx vertx) {
-    JsonObject config = configWithSslEnabledUsingString(vertx);
+  private JsonObject configWithSslEnabledByStringMissingKey(Vertx vertx) {
+    JsonObject config = configWithSslEnabledByString(vertx);
     config.remove("KROKI_SSL_KEY");
     return config;
   }
 
-  private JsonObject configWithSslEnabledUsingString(Vertx vertx) {
+  private JsonObject configWithSslEnabledByString(Vertx vertx) {
     return new JsonObject()
       .put("KROKI_PORT", port)
       .put("KROKI_SSL", true)
@@ -190,13 +190,13 @@ class ServerSSLTest {
       .put("KROKI_SSL_CERT", vertx.fileSystem().readFileBlocking(pemKeyCertOptions.getCertPath()).toString());
   }
 
-  private JsonObject configWithSslEnabledUsingPathMissingKey(Vertx vertx) {
-    JsonObject config = configWithSslEnabledUsingPath(vertx);
+  private JsonObject configWithSslEnabledByPathMissingKey(Vertx vertx) {
+    JsonObject config = configWithSslEnabledByPath(vertx);
     config.remove("KROKI_SSL_KEY_PATH");
     return config;
   }
 
-  private JsonObject configWithSslEnabledUsingPath(Vertx vertx) {
+  private JsonObject configWithSslEnabledByPath(Vertx vertx) {
     return new JsonObject()
       .put("KROKI_PORT", port)
       .put("KROKI_SSL", true)

--- a/server/src/test/java/io/kroki/server/ServerSSLTest.java
+++ b/server/src/test/java/io/kroki/server/ServerSSLTest.java
@@ -72,7 +72,7 @@ class ServerSSLTest {
           testContext.completeNow();
         })));
     };
-    vertx.deployVerticle(new Server(), new DeploymentOptions().setConfig(configWithSslEnabled(vertx)), handle);
+    vertx.deployVerticle(new Server(), new DeploymentOptions().setConfig(configWithSslEnabledAsString(vertx)), handle);
   }
 
   @Test
@@ -87,7 +87,7 @@ class ServerSSLTest {
         .as(BodyCodec.string())
         .send(testContext.failing(response -> testContext.verify(testContext::completeNow)));
     };
-    vertx.deployVerticle(new Server(), new DeploymentOptions().setConfig(configWithSslEnabled(vertx)), handle);
+    vertx.deployVerticle(new Server(), new DeploymentOptions().setConfig(configWithSslEnabledAsString(vertx)), handle);
   }
 
   @Test
@@ -109,7 +109,7 @@ class ServerSSLTest {
         .as(BodyCodec.string())
         .send(testContext.failing(response -> testContext.verify(testContext::completeNow)));
     };
-    vertx.deployVerticle(new Server(), new DeploymentOptions().setConfig(configWithSslEnabledMissingKey(vertx)), handle);
+    vertx.deployVerticle(new Server(), new DeploymentOptions().setConfig(configWithSslEnabledAsStringMissingKey(vertx)), handle);
   }
 
   private JsonObject configWithSslDisabled() {
@@ -118,17 +118,31 @@ class ServerSSLTest {
       .put("KROKI_SSL", false);
   }
 
-  private JsonObject configWithSslEnabledMissingKey(Vertx vertx) {
-    JsonObject config = configWithSslEnabled(vertx);
+  private JsonObject configWithSslEnabledAsStringMissingKey(Vertx vertx) {
+    JsonObject config = configWithSslEnabledAsString(vertx);
     config.remove("KROKI_SSL_KEY");
     return config;
   }
 
-  private JsonObject configWithSslEnabled(Vertx vertx) {
+  private JsonObject configWithSslEnabledAsString(Vertx vertx) {
     return new JsonObject()
       .put("KROKI_PORT", port)
       .put("KROKI_SSL", true)
       .put("KROKI_SSL_KEY", vertx.fileSystem().readFileBlocking(pemKeyCertOptions.getKeyPath()).toString())
       .put("KROKI_SSL_CERT", vertx.fileSystem().readFileBlocking(pemKeyCertOptions.getCertPath()).toString());
+  }
+
+  private JsonObject configWithSslEnabledAsPathMissingKey(Vertx vertx) {
+    JsonObject config = configWithSslEnabledAsPath(vertx);
+    config.remove("KROKI_SSL_KEY_PATH");
+    return config;
+  }
+
+  private JsonObject configWithSslEnabledAsPath(Vertx vertx) {
+    return new JsonObject()
+      .put("KROKI_PORT", port)
+      .put("KROKI_SSL", true)
+      .put("KROKI_SSL_KEY_PATH", pemKeyCertOptions.getKeyPath())
+      .put("KROKI_SSL_CERT_PATH", pemKeyCertOptions.getCertPath());
   }
 }

--- a/server/src/test/java/io/kroki/server/ServerSSLTest.java
+++ b/server/src/test/java/io/kroki/server/ServerSSLTest.java
@@ -170,6 +170,50 @@ class ServerSSLTest {
     vertx.deployVerticle(new Server(), new DeploymentOptions().setConfig(configWithSslEnabledByPathMissingKey(vertx)), handle);
   }
 
+  @Test
+  void with_ssl_enabled_by_string_and_missing_ssl_cert_config(Vertx vertx, VertxTestContext testContext) {
+    Handler<AsyncResult<String>> handle = deployVerticleResult -> {
+      // failed deployment
+      testContext.verify(() -> {
+        assertThat(deployVerticleResult.failed()).isTrue();
+        assertThat(deployVerticleResult.cause()).isInstanceOf(IllegalArgumentException.class);
+        assertThat(deployVerticleResult.cause()).hasMessage("KROKI_SSL_CERT or KROKI_SSL_CERT_PATH must be configured when SSL is enabled.");
+      });
+      WebClientOptions options = new WebClientOptions();
+      options.setSsl(true);
+      options.setTrustAll(true);
+      WebClient client = WebClient.create(vertx, options);
+      // failed request, server has not started
+      client
+        .get(port, "localhost", "/")
+        .as(BodyCodec.string())
+        .send(testContext.failing(response -> testContext.verify(testContext::completeNow)));
+    };
+    vertx.deployVerticle(new Server(), new DeploymentOptions().setConfig(configWithSslEnabledByStringMissingCert(vertx)), handle);
+  }
+
+  @Test
+  void with_ssl_enabled_by_path_and_missing_ssl_cert_config(Vertx vertx, VertxTestContext testContext) {
+    Handler<AsyncResult<String>> handle = deployVerticleResult -> {
+      // failed deployment
+      testContext.verify(() -> {
+        assertThat(deployVerticleResult.failed()).isTrue();
+        assertThat(deployVerticleResult.cause()).isInstanceOf(IllegalArgumentException.class);
+        assertThat(deployVerticleResult.cause()).hasMessage("KROKI_SSL_CERT or KROKI_SSL_CERT_PATH must be configured when SSL is enabled.");
+      });
+      WebClientOptions options = new WebClientOptions();
+      options.setSsl(true);
+      options.setTrustAll(true);
+      WebClient client = WebClient.create(vertx, options);
+      // failed request, server has not started
+      client
+        .get(port, "localhost", "/")
+        .as(BodyCodec.string())
+        .send(testContext.failing(response -> testContext.verify(testContext::completeNow)));
+    };
+    vertx.deployVerticle(new Server(), new DeploymentOptions().setConfig(configWithSslEnabledByPathMissingCert(vertx)), handle);
+  }
+
   private JsonObject configWithSslDisabled() {
     return new JsonObject()
       .put("KROKI_PORT", port)
@@ -179,6 +223,12 @@ class ServerSSLTest {
   private JsonObject configWithSslEnabledByStringMissingKey(Vertx vertx) {
     JsonObject config = configWithSslEnabledByString(vertx);
     config.remove("KROKI_SSL_KEY");
+    return config;
+  }
+
+  private JsonObject configWithSslEnabledByStringMissingCert(Vertx vertx) {
+    JsonObject config = configWithSslEnabledByString(vertx);
+    config.remove("KROKI_SSL_CERT");
     return config;
   }
 
@@ -193,6 +243,12 @@ class ServerSSLTest {
   private JsonObject configWithSslEnabledByPathMissingKey(Vertx vertx) {
     JsonObject config = configWithSslEnabledByPath(vertx);
     config.remove("KROKI_SSL_KEY_PATH");
+    return config;
+  }
+
+  private JsonObject configWithSslEnabledByPathMissingCert(Vertx vertx) {
+    JsonObject config = configWithSslEnabledByPath(vertx);
+    config.remove("KROKI_SSL_CERT_PATH");
     return config;
   }
 


### PR DESCRIPTION
Allows the SSL certificate and private key to be passed to the Docker image as a file path instead of a string (see #1512). This includes the following changes:

- Adds two new environment variables `KROKI_SSL_KEY_PATH` and `KROKI_SSL_CERT_PATH`. These are given lower priority than the existing `KROKI_SSL_KEY` and `KROKI_SSL_CERT` variables in case of multiple definitions.
- Adds new server tests to check for correct SSL setup in both possible cases (certificate + key provided as strings or as paths).
- Updates the documentation to describe both possible options.