### PR TITLE
Remove deprecated installLocalDependencies workflow step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,8 +15,6 @@ jobs:
         with:
           java-version: 11
           distribution: temurin
-      - name: Install Java dependencies
-        run: make installLocalDependencies
       - name: Build Java server
         run: make buildServer
       - run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
@@ -50,8 +48,6 @@ jobs:
         with:
           java-version: 11
           distribution: temurin
-      - name: Install Java dependencies
-        run: make installLocalDependencies
       - name: Build Java server
         run: make buildServer
       - name: Set up QEMU

--- a/README.adoc
+++ b/README.adoc
@@ -115,11 +115,7 @@ A companion web server written in Python (powered by _Flask_ and _Gunicorn_) tha
 
 === Gateway Server
 
-The first step is to install the local dependencies in your local repository using `make`:
-
- $ make installLocalDependencies
-
-Then you can build the project using Maven:
+The first step is to build the project using Maven:
 
  $ make buildServer
 


### PR DESCRIPTION
Removes the `installLocalDependencies` step from the `release` workflow and README after being deprecated in #1537.