### PR TITLE
Add missing Docker arguments for arm64 builds

### DIFF
--- a/bpmn/Dockerfile
+++ b/bpmn/Dockerfile
@@ -8,9 +8,10 @@ RUN npm config set unsafe-perm true
 
 RUN npm install -g pkg@5.6.0 pkg-fetch@3.3.0
 
+ARG TARGETARCH
+ARG TARGETOS
 ENV NODE node16
-ENV PLATFORM alpine
-RUN /usr/local/bin/pkg-fetch -n ${NODE} -p ${PLATFORM} -a $([ "$TARGETARCH" == "amd64" ] && echo "x64" || echo "$TARGETARCH")
+RUN /usr/local/bin/pkg-fetch -n $NODE -p $TARGETOS -a $([ "$TARGETARCH" = "amd64" ] && echo "x64" || echo "$TARGETARCH")
 
 COPY package.json package-lock.json /app/
 COPY src /app/src
@@ -19,7 +20,7 @@ WORKDIR /app
 RUN PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=1 npm ci
 RUN npm run lint
 
-RUN /usr/local/bin/pkg --targets ${NODE}-${PLATFORM}-$([ "$TARGETARCH" == "amd64" ] && echo "x64" || echo "$TARGETARCH") . -o app.bin
+RUN /usr/local/bin/pkg --targets $NODE-$TARGETOS-$([ "$TARGETARCH" = "amd64" ] && echo "x64" || echo "$TARGETARCH") . -o app.bin
 
 # Create the image
 FROM alpine:3.16.3

--- a/bpmn/Dockerfile
+++ b/bpmn/Dockerfile
@@ -17,7 +17,7 @@ COPY package.json package-lock.json /app/
 COPY src /app/src
 WORKDIR /app
 
-RUN PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=1 npm ci
+RUN PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=1 npm ci --target_arch=$([ "$TARGETARCH" = "amd64" ] && echo "x64" || echo "$TARGETARCH") --target_platform=$TARGETOS
 RUN npm run lint
 
 RUN /usr/local/bin/pkg --targets $NODE-$TARGETOS-$([ "$TARGETARCH" = "amd64" ] && echo "x64" || echo "$TARGETARCH") . -o app.bin

--- a/bpmn/Dockerfile
+++ b/bpmn/Dockerfile
@@ -9,18 +9,18 @@ RUN npm config set unsafe-perm true
 RUN npm install -g pkg@5.6.0 pkg-fetch@3.3.0
 
 ARG TARGETARCH
-ARG TARGETOS
 ENV NODE node16
-RUN /usr/local/bin/pkg-fetch -n $NODE -p $TARGETOS -a $([ "$TARGETARCH" = "amd64" ] && echo "x64" || echo "$TARGETARCH")
+ENV PLATFORM alpine
+RUN /usr/local/bin/pkg-fetch -n $NODE -p $PLATFORM -a $([ "$TARGETARCH" = "amd64" ] && echo "x64" || echo "$TARGETARCH")
 
 COPY package.json package-lock.json /app/
 COPY src /app/src
 WORKDIR /app
 
-RUN PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=1 npm ci --target_arch=$([ "$TARGETARCH" = "amd64" ] && echo "x64" || echo "$TARGETARCH") --target_platform=$TARGETOS
+RUN PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=1 npm ci --target_arch=$([ "$TARGETARCH" = "amd64" ] && echo "x64" || echo "$TARGETARCH") --target_platform=$PLATFORM
 RUN npm run lint
 
-RUN /usr/local/bin/pkg --targets $NODE-$TARGETOS-$([ "$TARGETARCH" = "amd64" ] && echo "x64" || echo "$TARGETARCH") . -o app.bin
+RUN /usr/local/bin/pkg --targets $NODE-$PLATFORM-$([ "$TARGETARCH" = "amd64" ] && echo "x64" || echo "$TARGETARCH") . -o app.bin
 
 # Create the image
 FROM alpine:3.16.3

--- a/diagrams.net/Dockerfile
+++ b/diagrams.net/Dockerfile
@@ -8,9 +8,10 @@ RUN npm config set unsafe-perm true
 
 RUN npm install -g pkg@5.6.0 pkg-fetch@3.3.0
 
+ARG TARGETARCH
+ARG TARGETOS
 ENV NODE node16
-ENV PLATFORM alpine
-RUN /usr/local/bin/pkg-fetch -n ${NODE} -p ${PLATFORM} -a $([ "$TARGETARCH" == "amd64" ] && echo "x64" || echo "$TARGETARCH")
+RUN /usr/local/bin/pkg-fetch -n $NODE -p $TARGETOS -a $([ "$TARGETARCH" = "amd64" ] && echo "x64" || echo "$TARGETARCH")
 
 COPY package.json package-lock.json /app/
 COPY src /app/src
@@ -19,7 +20,7 @@ WORKDIR /app
 RUN PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=1 npm ci
 RUN npm run lint
 
-RUN /usr/local/bin/pkg --targets ${NODE}-${PLATFORM}-$([ "$TARGETARCH" == "amd64" ] && echo "x64" || echo "$TARGETARCH") . -o app.bin
+RUN /usr/local/bin/pkg --targets $NODE-$TARGETOS-$([ "$TARGETARCH" = "amd64" ] && echo "x64" || echo "$TARGETARCH") . -o app.bin
 
 # Create the image
 FROM alpine:3.16.3

--- a/diagrams.net/Dockerfile
+++ b/diagrams.net/Dockerfile
@@ -17,7 +17,7 @@ COPY package.json package-lock.json /app/
 COPY src /app/src
 WORKDIR /app
 
-RUN PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=1 npm ci
+RUN PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=1 npm ci --target_arch=$([ "$TARGETARCH" = "amd64" ] && echo "x64" || echo "$TARGETARCH") --target_platform=$TARGETOS
 RUN npm run lint
 
 RUN /usr/local/bin/pkg --targets $NODE-$TARGETOS-$([ "$TARGETARCH" = "amd64" ] && echo "x64" || echo "$TARGETARCH") . -o app.bin

--- a/diagrams.net/Dockerfile
+++ b/diagrams.net/Dockerfile
@@ -9,18 +9,18 @@ RUN npm config set unsafe-perm true
 RUN npm install -g pkg@5.6.0 pkg-fetch@3.3.0
 
 ARG TARGETARCH
-ARG TARGETOS
 ENV NODE node16
-RUN /usr/local/bin/pkg-fetch -n $NODE -p $TARGETOS -a $([ "$TARGETARCH" = "amd64" ] && echo "x64" || echo "$TARGETARCH")
+ENV PLATFORM alpine
+RUN /usr/local/bin/pkg-fetch -n $NODE -p $PLATFORM -a $([ "$TARGETARCH" = "amd64" ] && echo "x64" || echo "$TARGETARCH")
 
 COPY package.json package-lock.json /app/
 COPY src /app/src
 WORKDIR /app
 
-RUN PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=1 npm ci --target_arch=$([ "$TARGETARCH" = "amd64" ] && echo "x64" || echo "$TARGETARCH") --target_platform=$TARGETOS
+RUN PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=1 npm ci --target_arch=$([ "$TARGETARCH" = "amd64" ] && echo "x64" || echo "$TARGETARCH") --target_platform=$PLATFORM
 RUN npm run lint
 
-RUN /usr/local/bin/pkg --targets $NODE-$TARGETOS-$([ "$TARGETARCH" = "amd64" ] && echo "x64" || echo "$TARGETARCH") . -o app.bin
+RUN /usr/local/bin/pkg --targets $NODE-$PLATFORM-$([ "$TARGETARCH" = "amd64" ] && echo "x64" || echo "$TARGETARCH") . -o app.bin
 
 # Create the image
 FROM alpine:3.16.3

--- a/excalidraw/Dockerfile
+++ b/excalidraw/Dockerfile
@@ -9,20 +9,20 @@ RUN npm config set unsafe-perm true
 RUN npm install -g pkg@5.6.0 pkg-fetch@3.3.0
 
 ARG TARGETARCH
-ARG TARGETOS
 ENV NODE node16
-RUN /usr/local/bin/pkg-fetch -n $NODE -p $TARGETOS -a $([ "$TARGETARCH" = "amd64" ] && echo "x64" || echo "$TARGETARCH")
+ENV PLATFORM alpine
+RUN /usr/local/bin/pkg-fetch -n $NODE -p $PLATFORM -a $([ "$TARGETARCH" = "amd64" ] && echo "x64" || echo "$TARGETARCH")
 
 COPY package.json package-lock.json /app/
 COPY src /app/src
 COPY assets /app/assets
 WORKDIR /app
 
-RUN PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=1 npm ci --target_arch=$([ "$TARGETARCH" = "amd64" ] && echo "x64" || echo "$TARGETARCH") --target_platform=$TARGETOS
+RUN PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=1 npm ci --target_arch=$([ "$TARGETARCH" = "amd64" ] && echo "x64" || echo "$TARGETARCH") --target_platform=$PLATFORM
 RUN npm run lint
 RUN npm run prestart
 
-RUN /usr/local/bin/pkg --targets $NODE-$TARGETOS-$([ "$TARGETARCH" = "amd64" ] && echo "x64" || echo "$TARGETARCH") . -o app.bin
+RUN /usr/local/bin/pkg --targets $NODE-$PLATFORM-$([ "$TARGETARCH" = "amd64" ] && echo "x64" || echo "$TARGETARCH") . -o app.bin
 
 # Create the image
 FROM alpine:3.16.3

--- a/excalidraw/Dockerfile
+++ b/excalidraw/Dockerfile
@@ -18,7 +18,7 @@ COPY src /app/src
 COPY assets /app/assets
 WORKDIR /app
 
-RUN PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=1 npm ci
+RUN PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=1 npm ci --target_arch=$([ "$TARGETARCH" = "amd64" ] && echo "x64" || echo "$TARGETARCH") --target_platform=$TARGETOS
 RUN npm run lint
 RUN npm run prestart
 

--- a/excalidraw/Dockerfile
+++ b/excalidraw/Dockerfile
@@ -8,9 +8,10 @@ RUN npm config set unsafe-perm true
 
 RUN npm install -g pkg@5.6.0 pkg-fetch@3.3.0
 
+ARG TARGETARCH
+ARG TARGETOS
 ENV NODE node16
-ENV PLATFORM alpine
-RUN /usr/local/bin/pkg-fetch -n ${NODE} -p ${PLATFORM} -a $([ "$TARGETARCH" == "amd64" ] && echo "x64" || echo "$TARGETARCH")
+RUN /usr/local/bin/pkg-fetch -n $NODE -p $TARGETOS -a $([ "$TARGETARCH" = "amd64" ] && echo "x64" || echo "$TARGETARCH")
 
 COPY package.json package-lock.json /app/
 COPY src /app/src
@@ -21,7 +22,7 @@ RUN PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=1 npm ci
 RUN npm run lint
 RUN npm run prestart
 
-RUN /usr/local/bin/pkg --targets ${NODE}-${PLATFORM}-$([ "$TARGETARCH" == "amd64" ] && echo "x64" || echo "$TARGETARCH") . -o app.bin
+RUN /usr/local/bin/pkg --targets $NODE-$TARGETOS-$([ "$TARGETARCH" = "amd64" ] && echo "x64" || echo "$TARGETARCH") . -o app.bin
 
 # Create the image
 FROM alpine:3.16.3


### PR DESCRIPTION
Adds missing `TARGETARCH` and `TARGETOS` arguments to the BPMN, Diagrams.net, and Excalidraw Dockerfiles to fix the broken `arm64` builds of these images. Without these arguments, the binaries are always built for the host architecture (currently `amd64`) instead of the target.