### PR TITLE
Improve error code status

### DIFF
--- a/server/src/main/java/io/kroki/server/Server.java
+++ b/server/src/main/java/io/kroki/server/Server.java
@@ -167,7 +167,7 @@ public class Server extends AbstractVerticle {
     // Default route
     Route route = router.route("/*");
     route.handler(routingContext -> routingContext.fail(404));
-    ErrorHandler errorHandler = new ErrorHandler(vertx, false);
+    ErrorHandler errorHandler = new ErrorHandler(vertx, config.getBoolean("KROKI_DISPLAY_EXCEPTION_DETAILS", false));
     route.failureHandler(errorHandler);
 
     server

--- a/server/src/main/java/io/kroki/server/action/CommandStatusHandler.java
+++ b/server/src/main/java/io/kroki/server/action/CommandStatusHandler.java
@@ -1,11 +1,13 @@
 package io.kroki.server.action;
 
+import io.kroki.server.error.BadRequestException;
+
 public interface CommandStatusHandler {
 
   default byte[] handle(int exitValue, byte[] stdout, byte[] stderr) {
     if (exitValue != 0) {
       String errorMessage = new String(stdout) + new String(stderr);
-      throw new IllegalStateException(errorMessage + " (exit code " + exitValue + ")");
+      throw new BadRequestException(errorMessage + " (exit code " + exitValue + ")");
     }
     return stdout;
   }

--- a/server/src/main/java/io/kroki/server/error/ErrorHandler.java
+++ b/server/src/main/java/io/kroki/server/error/ErrorHandler.java
@@ -20,6 +20,7 @@ import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.List;
+import java.util.Objects;
 
 public class ErrorHandler implements io.vertx.ext.web.handler.ErrorHandler {
 
@@ -55,10 +56,13 @@ public class ErrorHandler implements io.vertx.ext.web.handler.ErrorHandler {
     HttpServerResponse response = context.response();
     Throwable failure = context.failure();
     int errorCode = context.statusCode();
-    String errorMessage = response.getStatusMessage();
-    String statusMessage = null;
+    final String errorMessage;
+    final String statusMessage;
     String htmlErrorMessage = null;
-    if (failure instanceof BadRequestException) {
+    if (errorCode == 404) {
+      statusMessage = "Not Found";
+      errorMessage = statusMessage;
+    } else if (failure instanceof BadRequestException) {
       errorCode = 400;
       errorMessage = failure.getMessage();
       statusMessage = "Bad Request";
@@ -70,23 +74,20 @@ public class ErrorHandler implements io.vertx.ext.web.handler.ErrorHandler {
       htmlErrorMessage = ((ServiceUnavailableException) failure).getMessageHTML();
     } else if (failure instanceof IllegalStateException) {
       errorCode = 500;
-      errorMessage = failure.getMessage();
-      if (errorMessage == null) {
-        errorMessage = "Internal Server Error";
-      }
+      errorMessage = Objects.requireNonNullElse(failure.getMessage(), "Internal Server Error");
+      statusMessage = "Internal Server Error";
     } else {
-      if (errorCode < 400 || errorCode > 500) {
+      if (errorCode < 400 || errorCode > 599) {
+        // unexpected error code!
+        logger.warn("Unexpected error code in ErrorHandler. Got: " + errorCode + ". Error code must be within 400 and 599, fallback to 500");
         errorCode = 500;
       }
       if (displayExceptionDetails) {
-        errorMessage = failure.getMessage();
-      }
-      if (errorMessage == null || errorMessage.trim().isEmpty()) {
+        errorMessage = Objects.requireNonNullElse(failure.getMessage(), "Internal Server Error");
+      } else {
         errorMessage = "Internal Server Error";
       }
-    }
-    if (statusMessage == null) {
-      statusMessage = errorMessage;
+      statusMessage = "Internal Server Error";
     }
     handleError(new ErrorContext(context.request(), context.response(), statusMessage, new ErrorInfo(context.failure(), errorCode, errorMessage, htmlErrorMessage)));
   }
@@ -128,7 +129,9 @@ public class ErrorHandler implements io.vertx.ext.web.handler.ErrorHandler {
       StringBuilder stack = new StringBuilder();
       if (failure != null && displayExceptionDetails) {
         for (StackTraceElement elem : failure.getStackTrace()) {
-          stack.append(htmlSanitizer.sanitize("<li>" + elem.toString() + "</li>"));
+          stack.append("<li>");
+          stack.append(htmlSanitizer.sanitize( elem.toString()));
+          stack.append("</li>");
         }
       }
       response.putHeader(HttpHeaders.CONTENT_TYPE, "text/html");

--- a/server/src/main/java/io/kroki/server/error/ErrorHandler.java
+++ b/server/src/main/java/io/kroki/server/error/ErrorHandler.java
@@ -14,6 +14,7 @@ import org.owasp.html.HtmlPolicyBuilder;
 import org.owasp.html.PolicyFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.event.Level;
 
 import javax.imageio.ImageIO;
 import java.awt.image.BufferedImage;
@@ -53,7 +54,6 @@ public class ErrorHandler implements io.vertx.ext.web.handler.ErrorHandler {
 
   @Override
   public void handle(RoutingContext context) {
-    HttpServerResponse response = context.response();
     Throwable failure = context.failure();
     int errorCode = context.statusCode();
     final String errorMessage;
@@ -95,8 +95,10 @@ public class ErrorHandler implements io.vertx.ext.web.handler.ErrorHandler {
   public void handleError(ErrorContext errorContext) {
     HttpServerResponse response = errorContext.getResponse();
     response.setStatusMessage(errorContext.getStatusMessage());
-    logging.error(errorContext.getRequest(), errorContext.getErrorInfo());
-    response.setStatusCode(errorContext.getErrorCode());
+    int errorCode = errorContext.getErrorCode();
+    Level level = (errorCode >= 400 && errorCode <= 499) ? Level.WARN : Level.ERROR;
+    logging.log(level, errorContext.getRequest(), errorContext.getErrorInfo());
+    response.setStatusCode(errorCode);
     ErrorInfo errorInfo = errorContext.getErrorInfo();
     if (!sendErrorResponseMIME(response, errorInfo) && !sendErrorAcceptMIME(response, errorContext.getAcceptableMimes(), errorInfo)) {
       // fallback plain/text

--- a/server/src/main/java/io/kroki/server/service/D2.java
+++ b/server/src/main/java/io/kroki/server/service/D2.java
@@ -71,7 +71,7 @@ public class D2 implements DiagramService {
 
   @Override
   public String getVersion() {
-    return "undefined";
+    return "0.4.1";
   }
 
   @Override

--- a/server/src/main/java/io/kroki/server/service/Excalidraw.java
+++ b/server/src/main/java/io/kroki/server/service/Excalidraw.java
@@ -47,7 +47,7 @@ public class Excalidraw implements DiagramService {
 
   @Override
   public String getVersion() {
-    return "undefined";
+    return "0.15.2";
   }
 
   @Override

--- a/server/src/main/java/io/kroki/server/service/Wireviz.java
+++ b/server/src/main/java/io/kroki/server/service/Wireviz.java
@@ -49,7 +49,7 @@ public class Wireviz implements DiagramService {
 
   @Override
   public String getVersion() {
-    return "undefined";
+    return "0.3.2";
   }
 
   @Override

--- a/server/src/main/resources/web/error.html
+++ b/server/src/main/resources/web/error.html
@@ -14,7 +14,7 @@
     <h2 class="title">{title}</h2>
     <article class="message is-danger">
       <div class="message-body">
-        <strong><code>{errorCode}</code> {errorMessage}</strong>
+        <strong id="error"><code>{errorCode}</code> {errorMessage}</strong>
         <ul id="stacktrace">{stackTrace}</ul>
       </div>
     </article>

--- a/server/src/main/resources/web/root/css/main.css
+++ b/server/src/main/resources/web/root/css/main.css
@@ -75,6 +75,15 @@ ul {
   list-style: none;
 }
 
+#error {
+  vertical-align: middle;
+}
+
+#stacktrace {
+  padding-left: 4em;
+  font-size: 0.95em;
+}
+
 button,
 input,
 select,

--- a/server/src/test/java/io/kroki/server/action/CommanderTest.java
+++ b/server/src/test/java/io/kroki/server/action/CommanderTest.java
@@ -1,5 +1,6 @@
 package io.kroki.server.action;
 
+import io.kroki.server.error.BadRequestException;
 import io.kroki.server.unit.TimeValue;
 import io.vertx.core.json.JsonObject;
 import org.junit.jupiter.api.Test;
@@ -56,7 +57,7 @@ class CommanderTest {
         byte[] result = new Commander(new JsonObject()).execute(source.getBytes(), "dot");
         assertThat(Files.exists(Paths.get("/tmp/blns.fail"))).isFalse();
         assertThat(new String(result)).isEqualTo("");
-      } catch (IllegalStateException e) {
+      } catch (BadRequestException e) {
         assertThat(e).hasMessageStartingWith("Error: <stdin>: syntax error in line");
         assertThat(e).hasMessageEndingWith(" (exit code 1)");
       }


### PR DESCRIPTION
Previously, we could return `404 OK` which was misleading.