### PR TITLE
D2 diagrams: document option 'sketch'

### DIFF
--- a/docs/modules/setup/pages/diagram-options.adoc
+++ b/docs/modules/setup/pages/diagram-options.adoc
@@ -42,6 +42,12 @@ With flag set, option takes effect.
 |Allowable Values
 |Description
 
+|sketch
+|_flag_ +
+empty string ("")
+|Render diagram as hand-drawn sketch +
+With flag set, option takes effect.
+
 |theme
 |
 * `default` (`0`)


### PR DESCRIPTION
This PR adds documentation for the newly added option 'sketch' for D2 diagrams.

**Side note**: https://docs.kroki.io hasn't deployed for quite some time now, documentation changes that are present for quite some time now are not reflected yet. Could you please regenerate the Antora based docs? Thanks!