### PR TITLE
Correct spelling of D2 theme

### DIFF
--- a/docs/modules/setup/pages/diagram-options.adoc
+++ b/docs/modules/setup/pages/diagram-options.adoc
@@ -45,7 +45,7 @@ With flag set, option takes effect.
 |theme
 |
 * `default` (`0`)
-* `neutral-grey` (`1`)
+* `neutral-gray` (`1`)
 * `flagship-terrastruct` (`3`)
 * `cool-classics` (`4`)
 * `mixed-berry-blue` (`5`)

--- a/server/src/main/java/io/kroki/server/service/D2.java
+++ b/server/src/main/java/io/kroki/server/service/D2.java
@@ -29,7 +29,7 @@ public class D2 implements DiagramService {
 
   private final Map<String, Integer> builtinThemes = Map.ofEntries(
     entry("default", 0),
-    entry("neutral-grey", 1),
+    entry("neutral-gray", 1),
     entry("flagship-terrastruct", 3),
     entry("cool-classics", 4),
     entry("mixed-berry-blue", 5),


### PR DESCRIPTION
The D2 [themes list](https://d2lang.com/tour/themes/), mentions `neutral-gray`, not `neutral-grey`.
I propose we should follow the original nomenclature here.