### PR TITLE
Add D2 layout engine option

### DIFF
--- a/ci/tests/smoke.js
+++ b/ci/tests/smoke.js
@@ -39,7 +39,7 @@ const tests = [
   { engine: 'diagramsnet', file: 'diagramsnet-venn.xml', options: {}, outputFormat: ['svg', 'png'] },
   { engine: 'diagramsnet', file: 'diagramsnet-infography.xml', options: { id: 'foo' }, outputFormat: ['svg', 'png'] },
   { engine: 'd2', file: 'connections.d2', options: {}, outputFormat: ['svg'] },
-  { engine: 'd2', file: 'connections.d2', options: {layout: 'elk'}, outputFormat: ['svg'] },
+  { engine: 'd2', file: 'connections.d2', options: { layout: 'elk' }, outputFormat: ['svg'] },
   { engine: 'd2', file: 'connections.d2', options: { sketch: 'true' }, outputFormat: ['svg'] },
   { engine: 'wireviz', file: 'wireviz.yaml', options: {}, outputFormat: ['svg', 'png'] },
   { engine: 'tikz', file: 'periodic-table.tex', options: {}, outputFormat: ['jpeg', 'pdf', 'png', 'svg'] }

--- a/ci/tests/smoke.js
+++ b/ci/tests/smoke.js
@@ -39,6 +39,7 @@ const tests = [
   { engine: 'diagramsnet', file: 'diagramsnet-venn.xml', options: {}, outputFormat: ['svg', 'png'] },
   { engine: 'diagramsnet', file: 'diagramsnet-infography.xml', options: { id: 'foo' }, outputFormat: ['svg', 'png'] },
   { engine: 'd2', file: 'connections.d2', options: {}, outputFormat: ['svg'] },
+  { engine: 'd2', file: 'connections.d2', options: {layout: 'elk'}, outputFormat: ['svg'] },
   { engine: 'd2', file: 'connections.d2', options: { sketch: 'true' }, outputFormat: ['svg'] },
   { engine: 'wireviz', file: 'wireviz.yaml', options: {}, outputFormat: ['svg', 'png'] },
   { engine: 'tikz', file: 'periodic-table.tex', options: {}, outputFormat: ['jpeg', 'pdf', 'png', 'svg'] }

--- a/docs/modules/setup/pages/diagram-options.adoc
+++ b/docs/modules/setup/pages/diagram-options.adoc
@@ -64,6 +64,12 @@ With flag set, option takes effect.
 
 |See: https://d2lang.com/tour/themes/
 
+|layout
+|
+* `dagre` (default)
+* `elk`
+|Use an alternate layout engine: https://d2lang.com/tour/layouts/
+
 |sketch
 |_flag_ +
 empty string ("")

--- a/server/src/main/java/io/kroki/server/service/D2.java
+++ b/server/src/main/java/io/kroki/server/service/D2.java
@@ -89,8 +89,8 @@ public class D2 implements DiagramService {
   private byte[] d2(byte[] source, JsonObject options) throws IOException, InterruptedException, IllegalStateException {
     List<String> commands = new ArrayList<>();
     commands.add(binPath);
-    String value = options.getString("theme");
-    if (value != null) {
+    String theme = options.getString("theme");
+    if (theme != null) {
       int themeId = 0;
       Integer builtinThemeId = builtinThemes.get(value.toLowerCase().replaceAll("\\s", "-"));
       if (builtinThemeId != null) {
@@ -103,6 +103,11 @@ public class D2 implements DiagramService {
         }
       }
       commands.add("--theme=" + themeId);
+    }
+    String layout = options.getString("layout");
+    // Only pass the layout argument if the ELK layout engine is requested (default is 'dagre')
+    if (layout == "elk") { 
+      commands.add("--layout=" + layout);
     }
     String sketch = options.getString("sketch");
     if (sketch != null) {

--- a/server/src/main/java/io/kroki/server/service/D2.java
+++ b/server/src/main/java/io/kroki/server/service/D2.java
@@ -92,12 +92,12 @@ public class D2 implements DiagramService {
     String theme = options.getString("theme");
     if (theme != null) {
       int themeId = 0;
-      Integer builtinThemeId = builtinThemes.get(value.toLowerCase().replaceAll("\\s", "-"));
+      Integer builtinThemeId = builtinThemes.get(theme.toLowerCase().replaceAll("\\s", "-"));
       if (builtinThemeId != null) {
         themeId = builtinThemeId;
       } else {
         try {
-          themeId = Integer.parseInt(value, 10);
+          themeId = Integer.parseInt(theme, 10);
         } catch (NumberFormatException e) {
           // ignore, fallback to 0
         }

--- a/server/src/main/java/io/kroki/server/service/D2.java
+++ b/server/src/main/java/io/kroki/server/service/D2.java
@@ -105,8 +105,8 @@ public class D2 implements DiagramService {
       commands.add("--theme=" + themeId);
     }
     String layout = options.getString("layout");
-    // Only pass the layout argument if the ELK layout engine is requested (default is 'dagre')
-    if (layout == "elk") { 
+    if (layout != null && layout.equals("elk")) {
+      // Only pass the layout argument if the ELK layout engine is requested (default is 'dagre')
       commands.add("--layout=" + layout);
     }
     String sketch = options.getString("sketch");


### PR DESCRIPTION
Adds support for alternate D2 layout engines (see [documentation](https://d2lang.com/tour/layouts/)). Currently this includes both the default layout engine, `dagre`, and an open-source third-party alternative, `ELK`.

The `TALA` engine is not supported because it is proprietary (non-free) and closed-source.

Output with no layout specified (`dagre` is used by default):

```
curl http://localhost:8000/d2/svg/eNo9zLkRgDAMRNF8q3ADtEAvvrExBvpPkH9A8rSjkdZvuwuKjpHMrILBLFhV_3xgw6RuRvRsupp50jM06LnIy6nJbyIXXF-3Hm6y-X5cSiFx > default.svg
```

![default](https://github.com/yuzutech/kroki/assets/10233016/7979d917-2c91-4f11-ab16-02e388742abe)

Output with `layout=elk`:

```
curl http://localhost:8000/d2/svg/eNo9zLkRgDAMRNF8q3ADtEAvvrExBvpPkH9A8rSjkdZvuwuKjpHMrILBLFhV_3xgw6RuRvRsupp50jM06LnIy6nJbyIXXF-3Hm6y-X5cSiFx?layout=elk > elk.svg
```

![elk](https://github.com/yuzutech/kroki/assets/10233016/5a72609a-b536-4caf-8970-9de0411dac6b)

Closes #1557