### PR TITLE
Adding a health check that can be used to determine if the worker is healthy

### DIFF
--- a/mermaid/src/index.js
+++ b/mermaid/src/index.js
@@ -12,7 +12,7 @@ import { create } from './browser-instance.js'
   const worker = new Worker(browser)
   const server = new http.Server(
     micro.serve(async (req, res) => {
-      // Add a /health-check route that renders a sample diagram by calling the worker
+      // Add a /health route that renders a sample diagram by calling the worker
       if (req.url === '/health') {
         await worker.convert(new Task('graph TD\nA-->B', false), new URLSearchParams())
 

--- a/mermaid/src/index.js
+++ b/mermaid/src/index.js
@@ -13,7 +13,7 @@ import { create } from './browser-instance.js'
   const server = new http.Server(
     micro.serve(async (req, res) => {
       // Add a /health-check route that renders a sample diagram by calling the worker
-      if (req.url === '/health-check') {
+      if (req.url === '/health') {
         await worker.convert(new Task('graph TD\nA-->B', false), new URLSearchParams())
 
         // We don't actually care about the output, we just want to make sure the worker is up and running

--- a/mermaid/src/index.js
+++ b/mermaid/src/index.js
@@ -12,6 +12,14 @@ import { create } from './browser-instance.js'
   const worker = new Worker(browser)
   const server = new http.Server(
     micro.serve(async (req, res) => {
+      // Add a /health-check route that renders a sample diagram by calling the worker
+      if (req.url === '/health-check') {
+        await worker.convert(new Task('graph TD\nA-->B', false), new URLSearchParams())
+
+        // We don't actually care about the output, we just want to make sure the worker is up and running
+        return micro.send(res, 200, 'OK')
+      }
+
       // TODO: add a /_status route (return mermaid version)
       // TODO: read the diagram source as plain text
       const url = new URL(req.url, 'http://localhost') // create a URL object. The base is not important here


### PR DESCRIPTION
I am using fly.io to deploy and it has health checks, but you can't specify a payload to send, has to be a simple request without any parameters.

## This PR
Adds `health` route (any method) that renders an example mermaid diagram to ensure the worker is responsive.

Related issues in show-me chatgpt plugin project:
https://github.com/bra1nDump/show-me-chatgpt-plugin/issues/42
https://github.com/bra1nDump/show-me-chatgpt-plugin/issues/26