### PR TITLE
Invalid CORS now returns a 403 (instead of 500)

### DIFF
--- a/server/src/main/java/io/kroki/server/error/ErrorHandler.java
+++ b/server/src/main/java/io/kroki/server/error/ErrorHandler.java
@@ -20,11 +20,44 @@ import javax.imageio.ImageIO;
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.util.AbstractMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 public class ErrorHandler implements io.vertx.ext.web.handler.ErrorHandler {
 
+  private static final Map<Integer, String> statusMessageMap = Map.ofEntries(
+    new AbstractMap.SimpleEntry<>(400, "Bad Request"),
+    new AbstractMap.SimpleEntry<>(401, "Unauthorized"),
+    new AbstractMap.SimpleEntry<>(402, "Payment Required"),
+    new AbstractMap.SimpleEntry<>(403, "Forbidden"),
+    new AbstractMap.SimpleEntry<>(404, "Not Found"),
+    new AbstractMap.SimpleEntry<>(405, "Method Not Allowed"),
+    new AbstractMap.SimpleEntry<>(406, "Not Acceptable"),
+    new AbstractMap.SimpleEntry<>(407, "Proxy Authentication Required"),
+    new AbstractMap.SimpleEntry<>(408, "Request Timeout"),
+    new AbstractMap.SimpleEntry<>(409, "Conflict"),
+    new AbstractMap.SimpleEntry<>(410, "Gone"),
+    new AbstractMap.SimpleEntry<>(411, "Length Required"),
+    new AbstractMap.SimpleEntry<>(412, "Precondition Failed"),
+    new AbstractMap.SimpleEntry<>(413, "Content Too Large"),
+    new AbstractMap.SimpleEntry<>(414, "URI Too Long"),
+    new AbstractMap.SimpleEntry<>(415, "Unsupported Media Type"),
+    new AbstractMap.SimpleEntry<>(416, "Range Not Satisfiable"),
+    new AbstractMap.SimpleEntry<>(417, "Expectation Failed"),
+    new AbstractMap.SimpleEntry<>(418, "I'm a teapot"),
+    new AbstractMap.SimpleEntry<>(421, "Misdirected Request"),
+    new AbstractMap.SimpleEntry<>(422, "Unprocessable Content"),
+    new AbstractMap.SimpleEntry<>(423, "Locked"),
+    new AbstractMap.SimpleEntry<>(424, "Failed Dependency"),
+    new AbstractMap.SimpleEntry<>(425, "Too Early"),
+    new AbstractMap.SimpleEntry<>(426, "Upgrade Required"),
+    new AbstractMap.SimpleEntry<>(428, "Precondition Required"),
+    new AbstractMap.SimpleEntry<>(429, "Too Many Requests"),
+    new AbstractMap.SimpleEntry<>(431, "Request Header Fields Too Large"),
+    new AbstractMap.SimpleEntry<>(451, "Unavailable For Legal Reasons")
+  );
   private static final Logger logger = LoggerFactory.getLogger(ErrorHandler.class);
   private final Logging logging;
 
@@ -62,20 +95,22 @@ public class ErrorHandler implements io.vertx.ext.web.handler.ErrorHandler {
     if (errorCode == 404) {
       statusMessage = "Not Found";
       errorMessage = statusMessage;
-    } else if (failure instanceof BadRequestException) {
-      errorCode = 400;
+    } else if (failure instanceof BadRequestException || failure instanceof IllegalStateException) {
+      if (errorCode < 400 || errorCode >= 500) {
+        errorCode = 400;
+        statusMessage = "Bad Request";
+      } else {
+        statusMessage = statusMessageMap.getOrDefault(errorCode, "Bad Request");
+      }
       errorMessage = failure.getMessage();
-      statusMessage = "Bad Request";
-      htmlErrorMessage = ((BadRequestException) failure).getMessageHTML();
+      if (failure instanceof BadRequestException) {
+        htmlErrorMessage = ((BadRequestException) failure).getMessageHTML();
+      }
     } else if (failure instanceof ServiceUnavailableException) {
       errorCode = 503;
       errorMessage = failure.getMessage();
       statusMessage = "Service Unavailable";
       htmlErrorMessage = ((ServiceUnavailableException) failure).getMessageHTML();
-    } else if (failure instanceof IllegalStateException) {
-      errorCode = 500;
-      errorMessage = Objects.requireNonNullElse(failure.getMessage(), "Internal Server Error");
-      statusMessage = "Internal Server Error";
     } else {
       if (errorCode < 400 || errorCode > 599) {
         // unexpected error code!
@@ -132,7 +167,7 @@ public class ErrorHandler implements io.vertx.ext.web.handler.ErrorHandler {
       if (failure != null && displayExceptionDetails) {
         for (StackTraceElement elem : failure.getStackTrace()) {
           stack.append("<li>");
-          stack.append(htmlSanitizer.sanitize( elem.toString()));
+          stack.append(htmlSanitizer.sanitize(elem.toString()));
           stack.append("</li>");
         }
       }
@@ -184,7 +219,7 @@ public class ErrorHandler implements io.vertx.ext.web.handler.ErrorHandler {
 
     if (mime.startsWith("image/png") || mime.startsWith("image/*")) {
       String completeErrorMessage = getCompleteErrorMessage(failure, errorCode, errorMessage);
-      try ( ByteArrayOutputStream output = new ByteArrayOutputStream()) {
+      try (ByteArrayOutputStream output = new ByteArrayOutputStream()) {
         BufferedImage bufferedImage = ErrorImage.buildPNGImage(completeErrorMessage);
         ImageIO.write(bufferedImage, "png", output);
         response.putHeader(HttpHeaders.CONTENT_TYPE, "image/png");


### PR DESCRIPTION
#### Before
```console
$ http :8000/graphviz/svg/eNpLyUwvSizIUHBXqPZIzcnJ17ULzy_KSanlAgB1EAjQ "Origin: lsp:///bad"
HTTP/1.1 500 Internal Server Error
content-length: 41
content-type: text/plain

Error 500: CORS Rejected - Invalid origin
```


#### After
```console
$ http :8000/graphviz/svg/eNpLyUwvSizIUHBXqPZIzcnJ17ULzy_KSanlAgB1EAjQ "Origin: lsp:///bad"
HTTP/1.1 403 Forbidden
content-length: 41
content-type: text/plain

Error 403: CORS Rejected - Invalid origin
```