### PR TITLE
Add PlantUML no-metadata option

### DIFF
--- a/ci/tests/smoke.js
+++ b/ci/tests/smoke.js
@@ -39,7 +39,7 @@ const tests = [
   { engine: 'diagramsnet', file: 'diagramsnet-venn.xml', options: {}, outputFormat: ['svg', 'png'] },
   { engine: 'diagramsnet', file: 'diagramsnet-infography.xml', options: { id: 'foo' }, outputFormat: ['svg', 'png'] },
   { engine: 'd2', file: 'connections.d2', options: {}, outputFormat: ['svg'] },
-  { engine: 'd2', file: 'connections.d2', options: {layout: 'elk'}, outputFormat: ['svg'] },
+  { engine: 'd2', file: 'connections.d2', options: { layout: 'elk' }, outputFormat: ['svg'] },
   { engine: 'd2', file: 'connections.d2', options: { sketch: 'true' }, outputFormat: ['svg'] },
   { engine: 'wireviz', file: 'wireviz.yaml', options: {}, outputFormat: ['svg', 'png'] },
   { engine: 'tikz', file: 'periodic-table.tex', options: {}, outputFormat: ['jpeg', 'pdf', 'png', 'svg'] }

--- a/ci/tests/smoke.js
+++ b/ci/tests/smoke.js
@@ -19,6 +19,7 @@ const tests = [
   { engine: 'mermaid', file: 'contribute.mmd', options: {}, outputFormat: ['svg'] },
   { engine: 'bpmn', file: 'example.bpmn', options: {}, outputFormat: ['svg'] },
   { engine: 'plantuml', file: 'architecture.puml', options: {}, outputFormat: ['svg', 'pdf', 'png', 'txt'] },
+  { engine: 'plantuml', file: 'architecture.puml', options: { 'no-metadata': 'true' }, outputFormat: ['svg', 'png'] },
   { engine: 'svgbob', file: 'cloud.bob', options: {}, outputFormat: ['svg'] },
   { engine: 'nomnoml', file: 'pirate.nomnoml', options: {}, outputFormat: ['svg'] },
   { engine: 'packetdiag', file: 'packet.diag', options: {}, outputFormat: ['svg', 'png'] },

--- a/ci/tests/smoke.js
+++ b/ci/tests/smoke.js
@@ -39,6 +39,7 @@ const tests = [
   { engine: 'diagramsnet', file: 'diagramsnet-venn.xml', options: {}, outputFormat: ['svg', 'png'] },
   { engine: 'diagramsnet', file: 'diagramsnet-infography.xml', options: { id: 'foo' }, outputFormat: ['svg', 'png'] },
   { engine: 'd2', file: 'connections.d2', options: {}, outputFormat: ['svg'] },
+  { engine: 'd2', file: 'connections.d2', options: {layout: 'elk'}, outputFormat: ['svg'] },
   { engine: 'd2', file: 'connections.d2', options: { sketch: 'true' }, outputFormat: ['svg'] },
   { engine: 'wireviz', file: 'wireviz.yaml', options: {}, outputFormat: ['svg', 'png'] },
   { engine: 'tikz', file: 'periodic-table.tex', options: {}, outputFormat: ['jpeg', 'pdf', 'png', 'svg'] }

--- a/docs/modules/setup/pages/diagram-options.adoc
+++ b/docs/modules/setup/pages/diagram-options.adoc
@@ -64,6 +64,12 @@ With flag set, option takes effect.
 
 |See: https://d2lang.com/tour/themes/
 
+|layout
+|
+* `dagre` (default)
+* `elk`
+|Use an alternate layout engine: https://d2lang.com/tour/layouts/
+
 |sketch
 |_flag_ +
 empty string ("")

--- a/docs/modules/setup/pages/diagram-options.adoc
+++ b/docs/modules/setup/pages/diagram-options.adoc
@@ -182,6 +182,10 @@ The complete list of options is available in Mermaid source code at: https://git
 
 |Use a specific theme (it will prepend the `!theme` directive in your diagram)
 
+|no-metadata
+|_flag_ +
+empty string ("")
+|Do not save the diagram's source code in the generated SVG/PNG metadata
 |===
 
 == Structurizr
@@ -233,7 +237,7 @@ The complete list of options is available in Mermaid source code at: https://git
 
 |stroke-width
 |_any_ +
-*`2`* 
+*`2`*
 |Stroke width for all lines
 
 |===

--- a/server/src/main/java/io/kroki/server/service/D2.java
+++ b/server/src/main/java/io/kroki/server/service/D2.java
@@ -89,8 +89,8 @@ public class D2 implements DiagramService {
   private byte[] d2(byte[] source, JsonObject options) throws IOException, InterruptedException, IllegalStateException {
     List<String> commands = new ArrayList<>();
     commands.add(binPath);
-    String value = options.getString("theme");
-    if (value != null) {
+    String theme = options.getString("theme");
+    if (theme != null) {
       int themeId = 0;
       Integer builtinThemeId = builtinThemes.get(value.toLowerCase().replaceAll("\\s", "-"));
       if (builtinThemeId != null) {
@@ -103,6 +103,11 @@ public class D2 implements DiagramService {
         }
       }
       commands.add("--theme=" + themeId);
+    }
+    String layout = options.getString("layout");
+    // Only pass the layout argument if the ELK layout engine is requested (default is 'dagre')
+    if (layout == "elk") { 
+      commands.add("--layout=" + layout);
     }
     String sketch = options.getString("sketch");
     if (sketch != null) {

--- a/server/src/main/java/io/kroki/server/service/D2.java
+++ b/server/src/main/java/io/kroki/server/service/D2.java
@@ -92,12 +92,12 @@ public class D2 implements DiagramService {
     String theme = options.getString("theme");
     if (theme != null) {
       int themeId = 0;
-      Integer builtinThemeId = builtinThemes.get(value.toLowerCase().replaceAll("\\s", "-"));
+      Integer builtinThemeId = builtinThemes.get(theme.toLowerCase().replaceAll("\\s", "-"));
       if (builtinThemeId != null) {
         themeId = builtinThemeId;
       } else {
         try {
-          themeId = Integer.parseInt(value, 10);
+          themeId = Integer.parseInt(theme, 10);
         } catch (NumberFormatException e) {
           // ignore, fallback to 0
         }

--- a/server/src/main/java/io/kroki/server/service/D2.java
+++ b/server/src/main/java/io/kroki/server/service/D2.java
@@ -105,8 +105,8 @@ public class D2 implements DiagramService {
       commands.add("--theme=" + themeId);
     }
     String layout = options.getString("layout");
-    // Only pass the layout argument if the ELK layout engine is requested (default is 'dagre')
-    if (layout == "elk") { 
+    if (layout != null && layout.equals("elk")) {
+      // Only pass the layout argument if the ELK layout engine is requested (default is 'dagre')
       commands.add("--layout=" + layout);
     }
     String sketch = options.getString("sketch");

--- a/server/src/main/java/io/kroki/server/service/PlantumlCommand.java
+++ b/server/src/main/java/io/kroki/server/service/PlantumlCommand.java
@@ -69,15 +69,19 @@ public class PlantumlCommand {
 
   public byte[] convert(String source, FileFormat format, JsonObject options) throws IOException, InterruptedException {
     List<String> commands = new ArrayList<>();
-    String theme = options.getString("theme");
     commands.add(binPath);
     commands.add("-pipe");
     commands.add("-t" + (format == FileFormat.BASE64 ? FileFormat.PNG.getName() : format.getName()));
     commands.add("-timeout");
     commands.add(String.valueOf(this.convertTimeout.timeUnit().toSeconds(this.convertTimeout.duration())));
+    String theme = options.getString("theme");
     if (theme != null && !theme.isBlank()) {
       commands.add("-theme");
       commands.add(theme);
+    }
+    String no_metadata = options.getString("no-metadata");
+    if (no_metadata != null) {
+      commands.add("-nometadata");
     }
     byte[] result = commander.execute(source.getBytes(), commands.toArray(new String[0]));
     if (format == FileFormat.BASE64) {


### PR DESCRIPTION
Adds support for the PlantUML `-nometadata` argument to prevent the diagram source code from being included as metadata in the generated SVG or PNG files. See the PlantUML [documentation](https://plantuml.com/command-line) for more information.

Default output (source code included as metadata at the bottom of the file):

```
curl http://localhost:8000/plantuml/svg/eNpljzEPgjAQhff-iguTDFQlcYMmuru5mwNO0tCWhjY6GP-7LRJTdHvv7r67d26QxuKEGiY0gyML5Y65b7GzEvblIalYbAfs6SK9oqOSvdFkPCi6ecYmaj2aXhFkZ5QmgycD2Ogg-V3SI4_OyTjgR5OzVwqc0NECNEHydtR2NGH3TK2dHjtSP3zViPmQd9W2ERmgg-iv3jGW4MC5-L-wTEJdi1XeRENRiFWOtMfnrclriQ5gJD-Z3x9beAM= > default.svg
```

```xml
<?xml version="1.0" encoding="us-ascii" standalone="no"?>
<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" contentStyleType="text/css" height="505.2083px" preserveAspectRatio="none" style="width:390px;height:505px;background:#FFFFFF;" version="1.1" viewBox="0 0 390 505" width="390.625px" zoomAndPan="magnify">
  <defs/>
  <g>
<!--cluster Main-->
    <g id="cluster_Main">
      <rect fill="none" height="196.6927" rx="3.2552" ry="3.2552" style="stroke:#181818;stroke-width:1.3020833333333333;" width="197.9167" x="9.1146" y="77.2135"/>
      <text fill="#000000" font-family="sans-serif" font-size="18.2292" font-weight="bold" lengthAdjust="spacing" textLength="46.875" x="13.0208" y="96.7384">Main</text>
    </g>
<!--cluster Base-->
    <g id="cluster_Base">
      <rect fill="none" height="180.5729" rx="3.2552" ry="3.2552" style="stroke:#181818;stroke-width:1.3020833333333333;" width="367.1875" x="15.625" y="316.875"/>
      <text fill="#000000" font-family="sans-serif" font-size="18.2292" font-weight="bold" lengthAdjust="spacing" textLength="49.4792" x="19.5313" y="336.3999">Base</text>
    </g>
    <g id="elem_main.view">
      <ellipse cx="108.0682" cy="142.0211" fill="#F1F1F1" rx="78.2114" ry="19.2346" style="stroke:#181818;stroke-width:0.6510416666666666;"/>
      <text fill="#000000" font-family="sans-serif" font-size="18.2292" lengthAdjust="spacing" textLength="87.2396" x="60.5421" y="146.9007">main.view</text>
    </g>
    <g id="elem_singleton">
      <ellipse cx="106.7663" cy="233.8497" fill="#F1F1F1" rx="75.2949" ry="19.2143" style="stroke:#181818;stroke-width:0.6510416666666666;"/>
      <text fill="#000000" font-family="sans-serif" font-size="18.2292" lengthAdjust="spacing" textLength="83.3333" x="61.1933" y="238.7294">singleton</text>
    </g>
    <g id="elem_base.component">
      <ellipse cx="257.8175" cy="452.7041" fill="#F1F1F1" rx="103.8852" ry="23.902" style="stroke:#181818;stroke-width:0.6510416666666666;"/>
      <text fill="#000000" font-family="sans-serif" font-size="18.2292" lengthAdjust="spacing" textLength="153.6458" x="178.7182" y="457.1371">base.component</text>
    </g>
    <g id="elem_component">
      <ellipse cx="277.3437" cy="382.6094" fill="#F1F1F1" rx="85.1823" ry="20.1615" style="stroke:#181818;stroke-width:0.6510416666666666;"/>
      <text fill="#000000" font-family="sans-serif" font-size="18.2292" lengthAdjust="spacing" textLength="104.1667" x="221.3541" y="387.489">component</text>
    </g>
    <g id="elem_model">
      <ellipse cx="91.1498" cy="382.6059" fill="#F1F1F1" rx="54.8868" ry="19.0121" style="stroke:#181818;stroke-width:0.6510416666666666;"/>
      <text fill="#000000" font-family="sans-serif" font-size="18.2292" lengthAdjust="spacing" textLength="55.9896" x="59.2488" y="387.4855">model</text>
    </g>
<!--entity main_ts-->
    <g id="elem_main_ts">
      <rect fill="#F1F1F1" height="47.2616" rx="3.2552" ry="3.2552" style="stroke:#181818;stroke-width:0.6510416666666666;" width="100.2604" x="57.9427" y="9.1146"/>
      <text fill="#000000" font-family="sans-serif" font-size="18.2292" font-weight="bold" lengthAdjust="spacing" textLength="74.2188" x="70.9635" y="39.0561">main.ts</text>
    </g>
<!--link component to base.component-->
    <g id="link_component_base.component">
      <path d="M271.7969,403.0729 C270.1432,408.7891 268.2943,415.1953 266.4844,421.4193 " fill="none" id="component-to-base.component" style="stroke:#181818;stroke-width:1.3020833333333333;stroke-dasharray:7.0,7.0;"/>
      <polygon fill="#181818" points="264.4141,427.3047,272.6953,417.513,266.237,421.0547,262.6953,414.5964,264.4141,427.3047" style="stroke:#181818;stroke-width:1.3020833333333333;"/>
    </g>
<!--link main_ts to main.view-->
    <g id="link_main_ts_main.view">
      <path d="M108.0729,56.6797 C108.0729,73.6458 108.0729,96.9141 108.0729,114.6615 " fill="none" id="main_ts-to-main.view" style="stroke:#181818;stroke-width:2.6041666666666665;"/>
      <polygon fill="#181818" points="108.0729,121.0807,113.2813,109.362,108.0729,114.5703,102.8646,109.362,108.0729,121.0807" style="stroke:#181818;stroke-width:2.6041666666666665;"/>
    </g>
<!--link main.view to component-->
    <g id="link_main.view_component">
      <path d="M138.75,160.2214 C159.5313,172.9427 186.3932,192.0182 204.4271,214.6484 C238.8411,257.8125 260.2474,319.7135 270.3776,354.6615 " fill="none" id="main.view-to-component" style="stroke:#181818;stroke-width:1.3020833333333333;"/>
      <polygon fill="#181818" points="272.474,360.7943,274.3073,348.102,270.7075,354.5281,264.2814,350.9283,272.474,360.7943" style="stroke:#181818;stroke-width:1.3020833333333333;"/>
    </g>
<!--link main.view to singleton-->
    <g id="link_main.view_singleton">
      <path d="M107.7995,161.8099 C107.6172,174.7396 107.3568,192.1745 107.1484,206.4974 " fill="none" id="main.view-to-singleton" style="stroke:#181818;stroke-width:1.3020833333333333;stroke-dasharray:7.0,7.0;"/>
      <polygon fill="#181818" points="107.0443,212.7865,112.4195,201.1433,107.1373,206.2767,102.0039,200.9945,107.0443,212.7865" style="stroke:#181818;stroke-width:1.3020833333333333;"/>
    </g>
<!--link singleton to model-->
    <g id="link_singleton_model">
      <path d="M104.7917,253.6719 C102.0313,279.5052 97.0052,326.4844 93.8802,355.6771 " fill="none" id="singleton-to-model" style="stroke:#181818;stroke-width:1.3020833333333333;"/>
      <polygon fill="#181818" points="93.0599,362.0964,99.478,350.9939,93.7482,355.6224,89.1197,349.8926,93.0599,362.0964" style="stroke:#181818;stroke-width:1.3020833333333333;"/>
    </g>
<!--SRC=[POyn3u8m48Nt_eeBamnK9N639hgxkPi3JjBGbeOsEXZ_koqIKtHxx-w-ktTkaCRYX1ecD8CZ2-MEkM-ninBsvI6fM6m7xEaYlQAZahtHP3mekdd69cezcbuHP6UK9eCd0zZe8FbTqYEFpiauu4UJirSAdD3H0ZH1ydRKTZHXzqojdHuxKZzyrOZva7VLjX4Pe8Fehzunbk30kVY_i4n2NOjLtaH3KOXLZhJ7vwt9QuaEO2G_cTy0]-->
  </g>
</svg>
```

Output with the `no-metadata` option:

```
curl http://localhost:8000/plantuml/svg/eNpljzEPgjAQhff-iguTDFQlcYMmuru5mwNO0tCWhjY6GP-7LRJTdHvv7r67d26QxuKEGiY0gyML5Y65b7GzEvblIalYbAfs6SK9oqOSvdFkPCi6ecYmaj2aXhFkZ5QmgycD2Ogg-V3SI4_OyTjgR5OzVwqc0NECNEHydtR2NGH3TK2dHjtSP3zViPmQd9W2ERmgg-iv3jGW4MC5-L-wTEJdi1XeRENRiFWOtMfnrclriQ5gJD-Z3x9beAM=?no-metadata > nometadata.svg
```

```xml
<?xml version="1.0" encoding="us-ascii" standalone="no"?>
<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" contentStyleType="text/css" height="505.2083px" preserveAspectRatio="none" style="width:390px;height:505px;background:#FFFFFF;" version="1.1" viewBox="0 0 390 505" width="390.625px" zoomAndPan="magnify">
  <defs/>
  <g>
<!--cluster Main-->
    <g id="cluster_Main">
      <rect fill="none" height="196.6927" rx="3.2552" ry="3.2552" style="stroke:#181818;stroke-width:1.3020833333333333;" width="197.9167" x="9.1146" y="77.2135"/>
      <text fill="#000000" font-family="sans-serif" font-size="18.2292" font-weight="bold" lengthAdjust="spacing" textLength="46.875" x="13.0208" y="96.7384">Main</text>
    </g>
<!--cluster Base-->
    <g id="cluster_Base">
      <rect fill="none" height="180.5729" rx="3.2552" ry="3.2552" style="stroke:#181818;stroke-width:1.3020833333333333;" width="367.1875" x="15.625" y="316.875"/>
      <text fill="#000000" font-family="sans-serif" font-size="18.2292" font-weight="bold" lengthAdjust="spacing" textLength="49.4792" x="19.5313" y="336.3999">Base</text>
    </g>
    <g id="elem_main.view">
      <ellipse cx="108.0682" cy="142.0211" fill="#F1F1F1" rx="78.2114" ry="19.2346" style="stroke:#181818;stroke-width:0.6510416666666666;"/>
      <text fill="#000000" font-family="sans-serif" font-size="18.2292" lengthAdjust="spacing" textLength="87.2396" x="60.5421" y="146.9007">main.view</text>
    </g>
    <g id="elem_singleton">
      <ellipse cx="106.7663" cy="233.8497" fill="#F1F1F1" rx="75.2949" ry="19.2143" style="stroke:#181818;stroke-width:0.6510416666666666;"/>
      <text fill="#000000" font-family="sans-serif" font-size="18.2292" lengthAdjust="spacing" textLength="83.3333" x="61.1933" y="238.7294">singleton</text>
    </g>
    <g id="elem_base.component">
      <ellipse cx="257.8175" cy="452.7041" fill="#F1F1F1" rx="103.8852" ry="23.902" style="stroke:#181818;stroke-width:0.6510416666666666;"/>
      <text fill="#000000" font-family="sans-serif" font-size="18.2292" lengthAdjust="spacing" textLength="153.6458" x="178.7182" y="457.1371">base.component</text>
    </g>
    <g id="elem_component">
      <ellipse cx="277.3437" cy="382.6094" fill="#F1F1F1" rx="85.1823" ry="20.1615" style="stroke:#181818;stroke-width:0.6510416666666666;"/>
      <text fill="#000000" font-family="sans-serif" font-size="18.2292" lengthAdjust="spacing" textLength="104.1667" x="221.3541" y="387.489">component</text>
    </g>
    <g id="elem_model">
      <ellipse cx="91.1498" cy="382.6059" fill="#F1F1F1" rx="54.8868" ry="19.0121" style="stroke:#181818;stroke-width:0.6510416666666666;"/>
      <text fill="#000000" font-family="sans-serif" font-size="18.2292" lengthAdjust="spacing" textLength="55.9896" x="59.2488" y="387.4855">model</text>
    </g>
<!--entity main_ts-->
    <g id="elem_main_ts">
      <rect fill="#F1F1F1" height="47.2616" rx="3.2552" ry="3.2552" style="stroke:#181818;stroke-width:0.6510416666666666;" width="100.2604" x="57.9427" y="9.1146"/>
      <text fill="#000000" font-family="sans-serif" font-size="18.2292" font-weight="bold" lengthAdjust="spacing" textLength="74.2188" x="70.9635" y="39.0561">main.ts</text>
    </g>
<!--link component to base.component-->
    <g id="link_component_base.component">
      <path d="M271.7969,403.0729 C270.1432,408.7891 268.2943,415.1953 266.4844,421.4193 " fill="none" id="component-to-base.component" style="stroke:#181818;stroke-width:1.3020833333333333;stroke-dasharray:7.0,7.0;"/>
      <polygon fill="#181818" points="264.4141,427.3047,272.6953,417.513,266.237,421.0547,262.6953,414.5964,264.4141,427.3047" style="stroke:#181818;stroke-width:1.3020833333333333;"/>
    </g>
<!--link main_ts to main.view-->
    <g id="link_main_ts_main.view">
      <path d="M108.0729,56.6797 C108.0729,73.6458 108.0729,96.9141 108.0729,114.6615 " fill="none" id="main_ts-to-main.view" style="stroke:#181818;stroke-width:2.6041666666666665;"/>
      <polygon fill="#181818" points="108.0729,121.0807,113.2813,109.362,108.0729,114.5703,102.8646,109.362,108.0729,121.0807" style="stroke:#181818;stroke-width:2.6041666666666665;"/>
    </g>
<!--link main.view to component-->
    <g id="link_main.view_component">
      <path d="M138.75,160.2214 C159.5313,172.9427 186.3932,192.0182 204.4271,214.6484 C238.8411,257.8125 260.2474,319.7135 270.3776,354.6615 " fill="none" id="main.view-to-component" style="stroke:#181818;stroke-width:1.3020833333333333;"/>
      <polygon fill="#181818" points="272.474,360.7943,274.3073,348.102,270.7075,354.5281,264.2814,350.9283,272.474,360.7943" style="stroke:#181818;stroke-width:1.3020833333333333;"/>
    </g>
<!--link main.view to singleton-->
    <g id="link_main.view_singleton">
      <path d="M107.7995,161.8099 C107.6172,174.7396 107.3568,192.1745 107.1484,206.4974 " fill="none" id="main.view-to-singleton" style="stroke:#181818;stroke-width:1.3020833333333333;stroke-dasharray:7.0,7.0;"/>
      <polygon fill="#181818" points="107.0443,212.7865,112.4195,201.1433,107.1373,206.2767,102.0039,200.9945,107.0443,212.7865" style="stroke:#181818;stroke-width:1.3020833333333333;"/>
    </g>
<!--link singleton to model-->
    <g id="link_singleton_model">
      <path d="M104.7917,253.6719 C102.0313,279.5052 97.0052,326.4844 93.8802,355.6771 " fill="none" id="singleton-to-model" style="stroke:#181818;stroke-width:1.3020833333333333;"/>
      <polygon fill="#181818" points="93.0599,362.0964,99.478,350.9939,93.7482,355.6224,89.1197,349.8926,93.0599,362.0964" style="stroke:#181818;stroke-width:1.3020833333333333;"/>
    </g>
  </g>
</svg>
```

Closes #1610