### PR TITLE
Add option for max header size

### DIFF
--- a/docs/modules/setup/pages/configuration.adoc
+++ b/docs/modules/setup/pages/configuration.adoc
@@ -216,6 +216,10 @@ TIP: Keep in mind that browsers also have a URI limit on `<img>` tags.
 Most modern browsers https://stackoverflow.com/questions/417142/what-is-the-maximum-length-of-a-url-in-different-browsers/417184#417184[support a URI length greater than 64000] on `<img>` tags but this value is probably a bit excessive.
 We recommend to use a maximum length that's not greater than 8192 and not greater than 5120 if you are supporting IE 11.
 
+== Max header size
+
+KROKI_MAX_HEADER_SIZE:: The maximum length of all headers. If the sum of the length of each header exceeds this value, 431 (Request Header Fields Too Large) response status code is sent. Defaults to 8192.
+
 == Excalidraw static assets
 
 By default, Excalidraw loads assets from a public CDN (https://unpkg.com).

--- a/server/src/main/java/io/kroki/server/Server.java
+++ b/server/src/main/java/io/kroki/server/Server.java
@@ -59,7 +59,9 @@ public class Server extends AbstractVerticle {
   static void start(Vertx vertx, VertxOptions vertxOptions, JsonObject config, Handler<AsyncResult<HttpServer>> listenHandler) {
     HttpServerOptions serverOptions = new HttpServerOptions();
     Optional<Integer> maxUriLength = Optional.ofNullable(config.getInteger("KROKI_MAX_URI_LENGTH"));
+    Optional<Integer> maxHeaderSize = Optional.ofNullable(config.getInteger("KROKI_MAX_HEADER_SIZE"));
     maxUriLength.ifPresent(serverOptions::setMaxInitialLineLength);
+    maxHeaderSize.ifPresent(serverOptions::setMaxHeaderSize);
     boolean enableSSL = config.getBoolean("KROKI_SSL", false);
     serverOptions.setSsl(enableSSL);
     setPemKeyCertOptions(config, serverOptions, enableSSL);


### PR DESCRIPTION
I've deployed Kroki to a setup where the XFCC header size is larger than the 8kb limit. This let's the user set their desired max header size.