### PR TITLE
Update Docker image to Java 17

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -189,10 +189,10 @@ jobs:
     - name: Install GraphViz
       run: sudo apt-get install graphviz -y
 
-    - name: Set up JDK 11
+    - name: Set up JDK 17
       uses: actions/setup-java@v4
       with:
-        java-version: 11
+        java-version: 17
         distribution: temurin
 
     - name: Build Java server

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,10 +12,10 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install GraphViz
         run: sudo apt-get install graphviz -y
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
-          java-version: 11
+          java-version: 17
           distribution: temurin
       - name: Build Java server
         run: make buildServer
@@ -38,10 +38,10 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install GraphViz
         run: sudo apt-get install graphviz -y
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
-          java-version: 11
+          java-version: 17
           distribution: temurin
       - name: Build Java server
         run: make buildServer

--- a/ci/tasks/update-versions.js
+++ b/ci/tasks/update-versions.js
@@ -142,7 +142,7 @@ try {
     diagramLibraryVersions.diagramsnet = [...diagramsnetVersionFound][0].groups.version
   }
 
-  const dockerfileContent = await fs.readFile(ospath.join(rootDir, 'server', 'ops', 'docker', 'jdk11-jammy', 'Dockerfile'), 'utf8')
+  const dockerfileContent = await fs.readFile(ospath.join(rootDir, 'server', 'ops', 'docker', 'jdk17-jammy', 'Dockerfile'), 'utf8')
   for (const line of dockerfileContent.split('\n')) {
     const d2VersionFound = line.match(/^ARG D2_VERSION="(?<version>.+)"$/)
     if (d2VersionFound) {

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -25,7 +25,7 @@ target "kroki" {
     bytefield = "./bytefield"
     tikz = "./tikz"
   }
-  dockerfile = "ops/docker/jdk11-jammy/Dockerfile"
+  dockerfile = "ops/docker/jdk17-jammy/Dockerfile"
   tags = ["yuzutech/kroki:${TAG}"]
   inherits = ["oci-labels"]
   labels = {

--- a/pom.xml
+++ b/pom.xml
@@ -19,8 +19,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.12.1</version>
         <configuration>
-          <source>8</source>
-          <target>8</target>
+          <source>11</source>
+          <target>11</target>
         </configuration>
       </plugin>
       <plugin>

--- a/server/README.adoc
+++ b/server/README.adoc
@@ -14,7 +14,7 @@ When a new version is available, we need to :
 
 . update the fork
 . run the following workflow: https://github.com/yuzutech/ditaa-mini/actions/workflows/native-image-on-demand.yml
-. update the argument variable `ARG DITAA_VERSION="x.y.z"` in `server/ops/docker/jdk11-jammy/Dockerfile`
+. update the argument variable `ARG DITAA_VERSION="x.y.z"` in `server/ops/docker/jdk17-jammy/Dockerfile`
 
 === PlantUML
 
@@ -24,7 +24,7 @@ When a new version is available, we need to:
 
 . update the fork
 . run the following workflow: https://github.com/yuzutech/plantuml/actions/workflows/native-image-on-demand.yml
-. update the argument variable `ARG PLANTUML_VERSION="x.y.z"` in `server/ops/docker/jdk11-jammy/Dockerfile`
+. update the argument variable `ARG PLANTUML_VERSION="x.y.z"` in `server/ops/docker/jdk17-jammy/Dockerfile`
 
 === UMLet
 
@@ -34,4 +34,4 @@ When a new version is available, we need to:
 
 . update the fork
 . run the following workflow: https://github.com/yuzutech/umlet/actions/workflows/release.yml
-. update the argument variable `ARG UMLET_VERSION="x.y.z"` in `server/ops/docker/jdk11-jammy/Dockerfile`
+. update the argument variable `ARG UMLET_VERSION="x.y.z"` in `server/ops/docker/jdk17-jammy/Dockerfile`

--- a/server/ops/docker/jdk17-jammy/Dockerfile
+++ b/server/ops/docker/jdk17-jammy/Dockerfile
@@ -232,7 +232,7 @@ RUN SVGBOB_VERSION=`cat Cargo.toml | grep "svgbob_cli =" | sed -r 's/.*"([^"]+)"
 # use a pre-built image to reduce build time
 
 ## yuzutech/kroki
-FROM eclipse-temurin:11.0.20.1_1-jre-jammy
+FROM eclipse-temurin:17.0.9_9-jre-jammy
 
 ARG D2_VERSION="0.6.3"
 ARG PLANTUML_VERSION="1.2023.13"


### PR DESCRIPTION
This updates the Java version Kroki uses to Java 17.

For now this is a draft as I found it a bit difficult to test Kroki locally.  (I have IPv6 disabled which some tests seem to require and at least one of the Vega tests fails locally because of some Node.js stuff not being in place as expected.  And even with a hack to get Node.js working it seems to generate a different SVG on my machine.)

Fixes #1688 when merged.