### PR TITLE
Copy symbolator binary from Docker image

### DIFF
--- a/server/ops/docker/jdk17-jammy/Dockerfile
+++ b/server/ops/docker/jdk17-jammy/Dockerfile
@@ -153,35 +153,6 @@ FROM yuzutech/kroki-builder-erd:0.2.1.0 AS kroki-builder-static-erd
 #  --ghc-options="-optc=-static" \
 #  --ghc-options="-w"
 
-## Symbolator
-FROM ubuntu:jammy AS kroki-builder-static-symbolator
-
-# Build from forked source because upstream is broken for the latest python3 versions
-ARG SYMBOLATOR_VERSION=1.2.2
-ARG SYMBOLATOR_SOURCE=git+https://github.com/zebreus/symbolator.git@v$SYMBOLATOR_VERSION
-
-RUN apt-get update && apt-get install --no-install-recommends --yes \
-    git \
-    pip \
-    python3-dev \
-    patchelf \
-    python3-gi-cairo \
-    python3-gi \
-    build-essential \
-    libpango1.0-dev && \
-    apt-get clean && apt-get autoremove
-
-WORKDIR /build
-
-# Install latest pip and setuptools
-RUN python3 -m pip install --upgrade pip setuptools
-RUN python3 -m pip install --upgrade nuitka
-# Install symbolator
-RUN python3 -m pip install --upgrade ${SYMBOLATOR_SOURCE}
-
-# Use nuitka to compile a static binary so we dont need python in the final image
-RUN python3 -m nuitka --onefile `which symbolator` --include-module=gi.overrides.Pango --include-module=gi._gi_cairo
-
 ## Pikchr
 FROM ubuntu:jammy AS kroki-builder-static-pikchr
 
@@ -225,11 +196,8 @@ RUN SVGBOB_VERSION=`cat Cargo.toml | grep "svgbob_cli =" | sed -r 's/.*"([^"]+)"
     rustup target add $RUST_TARGET_ARCH-unknown-linux-gnu && \
     cargo install --quiet --target $RUST_TARGET_ARCH-unknown-linux-gnu --version $SVGBOB_VERSION svgbob_cli
 
-## UMlet
-# use a pre-built image to reduce build time
-
-## PlantUML
-# use a pre-built image to reduce build time
+ARG SYMBOLATOR_VERSION=1.2.2
+FROM madmanfred/symbolator:v$SYMBOLATOR_VERSION as symbolator
 
 ## yuzutech/kroki
 FROM eclipse-temurin:17.0.10_7-jre-jammy
@@ -302,9 +270,9 @@ COPY --from=kroki-builder-nomnoml /app/app.bin /usr/bin/nomnoml
 COPY --from=kroki-builder-vega /app/app.bin /usr/bin/vega
 COPY --from=kroki-builder-dbml /app/app.bin /usr/bin/dbml
 COPY --from=kroki-builder-wavedrom /app/app.bin /usr/bin/wavedrom
-COPY --from=kroki-builder-static-symbolator /build/symbolator.bin /usr/bin/symbolator
 COPY --from=kroki-builder-bytefield /app/app.bin /usr/bin/bytefield
 COPY --from=kroki-builder-dvisvgm /usr/local/bin/dvisvgm /usr/bin/dvisvgm
+COPY --from=symbolator /build/symbolator.bin /usr/bin/symbolator
 COPY --from=tikz tikz2svg /usr/bin/tikz2svg
 
 COPY --chown=kroki:kroki ops/docker/logback.xml /etc/kroki/logback.xml

--- a/server/ops/docker/jdk17-jammy/Dockerfile
+++ b/server/ops/docker/jdk17-jammy/Dockerfile
@@ -272,7 +272,7 @@ COPY --from=kroki-builder-dbml /app/app.bin /usr/bin/dbml
 COPY --from=kroki-builder-wavedrom /app/app.bin /usr/bin/wavedrom
 COPY --from=kroki-builder-bytefield /app/app.bin /usr/bin/bytefield
 COPY --from=kroki-builder-dvisvgm /usr/local/bin/dvisvgm /usr/bin/dvisvgm
-COPY --from=symbolator /build/symbolator.bin /usr/bin/symbolator
+COPY --from=symbolator /usr/bin/symbolator /usr/bin/symbolator
 COPY --from=tikz tikz2svg /usr/bin/tikz2svg
 
 COPY --chown=kroki:kroki ops/docker/logback.xml /etc/kroki/logback.xml


### PR DESCRIPTION
Copies the `symbolator` binary from the image on the Docker [Hub](https://hub.docker.com/r/madmanfred/symbolator) instead of building it from source. This should slightly reduce the build time for Kroki.