### PR TITLE
Change max body size using envvars when rendering diagramas

### DIFF
--- a/diagrams.net/src/index.js
+++ b/diagrams.net/src/index.js
@@ -19,7 +19,7 @@ import { SyntaxError, TimeoutError, Worker } from './worker.js'
       const url = new URL(req.url, 'http://localhost') // create a URL object. The base is not important here
       const outputType = url.pathname.match(/\/(png|svg)$/)?.[1]
       if (outputType) {
-        const diagramSource = await micro.text(req, { limit: '1mb', encoding: 'utf8' })
+        const diagramSource = await micro.text(req, { limit: (process.env.KROKI_MAX_BODY_SIZE ?? '1mb'), encoding: 'utf8' })
         if (diagramSource) {
           try {
             const isPng = outputType === 'png'

--- a/excalidraw/src/index.js
+++ b/excalidraw/src/index.js
@@ -15,7 +15,7 @@ import { create } from './browser-instance.js'
     micro.serve(async (req, res) => {
       // TODO: add a /_status route (return excalidraw version)
       // TODO: read the diagram source as plain text
-      const diagramSource = await micro.text(req, { limit: '1mb', encoding: 'utf8' })
+      const diagramSource = await micro.text(req, { limit: (process.env.KROKI_MAX_BODY_SIZE ?? '1mb'), encoding: 'utf8' })
       if (diagramSource) {
         try {
           const svg = await worker.convert(new Task(diagramSource))

--- a/mermaid/src/index.js
+++ b/mermaid/src/index.js
@@ -27,7 +27,7 @@ import { create } from './browser-instance.js'
       const url = new URL(req.url, 'http://localhost') // create a URL object. The base is not important here
       const outputType = url.pathname.match(/\/(png|svg)$/)?.[1]
       if (outputType) {
-        const diagramSource = await micro.text(req, { limit: '1mb', encoding: 'utf8' })
+        const diagramSource = await micro.text(req, { limit: (process.env.KROKI_MAX_BODY_SIZE ?? '1mb'), encoding: 'utf8' })
         if (diagramSource) {
           try {
             const isPng = outputType === 'png'


### PR DESCRIPTION
From #1760 

Allow changing max body sizes using environment variables on mermaid, diagrams.net and excalidraw.

Would it be better to use three different variables, one for each tool (e.g. KROKI_DIAGRAMSNET_MAX_BODY_SIZE) ?