### PR TITLE
Structurizr DSL: set restricted parsing

### DIFF
--- a/server/src/main/java/io/kroki/server/service/Structurizr.java
+++ b/server/src/main/java/io/kroki/server/service/Structurizr.java
@@ -88,6 +88,7 @@ public class Structurizr implements DiagramService {
   static byte[] convert(String source, FileFormat fileFormat, PlantumlCommand plantumlCommand, StructurizrPlantUMLExporter structurizrPlantUMLExporter, JsonObject options) throws IOException, InterruptedException {
     StructurizrDslParser parser = new StructurizrDslParser();
     try {
+      parser.setRestricted(true);
       parser.parse(source);
       ViewSet viewSet = parser.getWorkspace().getViews();
       Collection<View> views = viewSet.getViews();


### PR DESCRIPTION
Enable restricted parsing to disable `!script` and other dangerous methods to be executed during parsing