### PR TITLE
Add mscgen support (fixes #12)

### DIFF
--- a/server/ops/docker/jdk17-noble/Dockerfile
+++ b/server/ops/docker/jdk17-noble/Dockerfile
@@ -235,6 +235,8 @@ RUN wget "https://github.com/yuzutech/blockdiag/releases/download/v${BLOCKDIAG_V
 RUN wget "https://github.com/yuzutech/WireViz/releases/download/v${WIREVIZ_VERSION}/wireviz-linux-${TARGETARCH}.bin" -O /usr/bin/wireviz && \
     chmod +x /usr/bin/wireviz
 
+RUN apt-get install --no-install-recommends --yes msc-generator-nox
+
 COPY --from=erd /root/.cabal/bin/erd /usr/bin/erd
 COPY --from=kroki-builder-bytefield /app/app.bin /usr/bin/bytefield
 COPY --from=kroki-builder-dbml /app/app.bin /usr/bin/dbml

--- a/server/src/main/java/io/kroki/server/Server.java
+++ b/server/src/main/java/io/kroki/server/Server.java
@@ -122,6 +122,7 @@ public class Server extends AbstractVerticle {
     registry.register(new TikZ(vertx, config, commander), "tikz");
     registry.register(new Dbml(vertx, config, commander), "dbml");
     registry.register(new Wireviz(vertx, config, commander), "wireviz");
+    registry.register(new MscGenerator(vertx, config, commander), "mscgen");
 
     router.post("/")
       .handler(bodyHandler)

--- a/server/src/main/java/io/kroki/server/service/MscGenerator.java
+++ b/server/src/main/java/io/kroki/server/service/MscGenerator.java
@@ -1,0 +1,85 @@
+package io.kroki.server.service;
+
+import io.kroki.server.action.Commander;
+import io.kroki.server.decode.DiagramSource;
+import io.kroki.server.decode.SourceDecoder;
+import io.kroki.server.error.DecodeException;
+import io.kroki.server.format.FileFormat;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.json.JsonObject;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class MscGenerator implements DiagramService {
+
+  private static final List<FileFormat> SUPPORTED_FORMATS = Arrays.asList(FileFormat.PNG, FileFormat.SVG, FileFormat.PDF);
+
+  private final Vertx vertx;
+  private final String binPath;
+  private final SourceDecoder sourceDecoder;
+  private final Commander commander;
+
+  public MscGenerator(Vertx vertx, JsonObject config, Commander commander) {
+    this.vertx = vertx;
+    this.binPath = config.getString("KROKI_MSCGEN_BIN_PATH", "msc-gen");
+    this.sourceDecoder = new SourceDecoder() {
+      @Override
+      public String decode(String encoded) throws DecodeException {
+        return DiagramSource.decode(encoded);
+      }
+    };
+    this.commander = commander;
+  }
+
+  @Override
+  public List<FileFormat> getSupportedFormats() {
+    return SUPPORTED_FORMATS;
+  }
+
+  @Override
+  public SourceDecoder getSourceDecoder() {
+    return sourceDecoder;
+  }
+
+  @Override
+  public String getVersion() {
+    try {
+      Process process = new ProcessBuilder(binPath, "--version").start();
+      String line = new BufferedReader(new InputStreamReader(process.getInputStream())).readLine();
+      return line.split("\\s+")[1].substring(1);
+    } catch (IOException e) {
+      return "unknown";
+    }
+  }
+
+  @Override
+  public void convert(String sourceDecoded, String serviceName, FileFormat fileFormat, JsonObject options, Handler<AsyncResult<Buffer>> handler) {
+    vertx.executeBlocking(future -> {
+      try {
+        byte[] result = mscgen(sourceDecoded.getBytes(), fileFormat.getName(), options);
+        future.complete(result);
+      } catch (IOException | InterruptedException | IllegalStateException e) {
+        future.fail(e);
+      }
+    }, res -> handler.handle(res.map(o -> Buffer.buffer((byte[]) o))));
+  }
+
+  private byte[] mscgen(byte[] source, String format, JsonObject options) throws IOException, InterruptedException, IllegalStateException {
+    return commander.execute(
+      source,
+      binPath,
+      "-S", options.getString("lang", "signalling"), // Supported languages: signalling | msc, graph, block
+      "-T", format,
+      "-s=" + options.getFloat("scale", 1.f),
+      "-"
+    );
+  }
+}


### PR DESCRIPTION
Message Sequence Chart (MSC) support is added using msc-generator [1] as suggested by [2]. The backend tool is installed into the server image from upstream Ubuntu, under the service endpoint "/mscgen". (Disclaimer: I'm packaging the tool for Debian.)
Msc-generator's signalling chart part is heavily extended and completely rewritten from Michael C McTernan’s mscgen with a lot of enhancements; and also supports block charts and generic graphs (dot format) as of today.

Please consider this PR as an extension to the impressive list of supported backends. I'd be happy to receive any comments.

[1] https://gitlab.com/msc-generator/msc-generator
[2] https://github.com/yuzutech/kroki/issues/12#issuecomment-1368139643
