### PR TITLE
chore: diagrams.net - add /health API for health checks 

### DIFF
--- a/diagrams.net/src/index.js
+++ b/diagrams.net/src/index.js
@@ -14,6 +14,14 @@ import { SyntaxError, TimeoutError, Worker } from './worker.js'
   const worker = new Worker(browser)
   const server = new http.Server(
     micro.serve(async (req, res) => {
+      // Add a /health route that renders a sample diagram by calling the worker
+      if (req.url === '/health') {
+        let sample = `<mxGraphModel><root><mxCell id="0"/><mxCell id="1" parent="0"/></root></mxGraphModel>`
+        await worker.convert(new Task(sample, false), new URLSearchParams())
+
+        // We don't actually care about the output, we just want to make sure the worker is up and running
+        return micro.send(res, 200, 'OK')
+      }
       // TODO: add a /_status route (return diagrams.net version)
       // TODO: read the diagram source as plain text
       const url = new URL(req.url, 'http://localhost') // create a URL object. The base is not important here

--- a/diagrams.net/src/index.js
+++ b/diagrams.net/src/index.js
@@ -16,7 +16,7 @@ import { SyntaxError, TimeoutError, Worker } from './worker.js'
     micro.serve(async (req, res) => {
       // Add a /health route that renders a sample diagram by calling the worker
       if (req.url === '/health') {
-        let sample = `<mxGraphModel><root><mxCell id="0"/><mxCell id="1" parent="0"/></root></mxGraphModel>`
+        const sample = `<mxGraphModel><root><mxCell id="0"/><mxCell id="1" parent="0"/></root></mxGraphModel>`
         await worker.convert(new Task(sample, false), new URLSearchParams())
 
         // We don't actually care about the output, we just want to make sure the worker is up and running


### PR DESCRIPTION
Hi team,

I found that `diagrams.net` is missing `/health` for the health check. That may lead to a failure in K8s when starting the instance, so I created this pull request to support it.

Please review it and give me comments if any!

Thank you!

