### PR TITLE
fix(plantuml): pass plantuml.include.path property to native plantuml binary

### DIFF
--- a/server/src/main/java/io/kroki/server/service/Plantuml.java
+++ b/server/src/main/java/io/kroki/server/service/Plantuml.java
@@ -125,11 +125,6 @@ public class Plantuml implements DiagramService {
     this.ditaaCommand = new DitaaCommand(config);
     this.includeWhitelist = parseIncludeWhitelist(config);
     this.logging = new Logging(logger);
-    // Disable unsafe include for security reasons
-    String plantUmlIncludePath = config.getString("KROKI_PLANTUML_INCLUDE_PATH");
-    if (plantUmlIncludePath != null) {
-      System.setProperty("plantuml.include.path", plantUmlIncludePath);
-    }
   }
 
   static List<Pattern> parseIncludeWhitelist(JsonObject config) {


### PR DESCRIPTION
I have found a way of passing the `plantuml.include.path` property to the native plantuml library.

It's worth noting that, plantuml has a `-D` parameter which sets value of global preprocessing variable as described here: https://plantuml.com/command-line, however when built using GraalVM into native library, the GraalVM handling of the `-D` parameter (described here: https://www.graalvm.org/latest/reference-manual/native-image/guides/use-system-properties/) takes precedence, which is the reason why this fix works.

I have added debug log message to add ability to see the exact plantuml command parameters which makes it easier to debug any problems with it, if necessary.

Please let me know what do you think.

Fixes #1765