### PR TITLE
Document /tmp:exec

### DIFF
--- a/docs/modules/setup/examples/kroki-docker-compose.yml
+++ b/docs/modules/setup/examples/kroki-docker-compose.yml
@@ -11,6 +11,9 @@ services:
       - KROKI_EXCALIDRAW_HOST=excalidraw
     ports:
       - "8000:8000"
+    # If you need at all to explicitly mount /tmp, add exec option.
+    tmpfs:
+      - /tmp:exec
   mermaid:
     image: yuzutech/kroki-mermaid
     expose:
@@ -23,3 +26,4 @@ services:
     image: yuzutech/kroki-excalidraw
     expose:
       - "8004"
+      

--- a/docs/modules/setup/examples/kroki-docker-compose.yml
+++ b/docs/modules/setup/examples/kroki-docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - KROKI_EXCALIDRAW_HOST=excalidraw
     ports:
       - "8000:8000"
-    # If you need at all to explicitly mount /tmp, add exec option.
+    # If you do need to explicitly mount /tmp, make sure to include the exec option
     tmpfs:
       - /tmp:exec
   mermaid:


### PR DESCRIPTION
Document the fact that, if /tmp is explicitly mounted into kroki container, the option exec: ought to be used.

Fixes: #1874