### PR TITLE
Modernize C# example

### DIFF
--- a/docs/modules/setup/examples/encode.cs
+++ b/docs/modules/setup/examples/encode.cs
@@ -5,60 +5,64 @@ using System.Text;
 
 class Program
 {
-    // uses System.IO, System.IO.Compression
-    // Reference: https://yal.cc/cs-deflatestream-zlib/#code
     static byte[] Deflate(byte[] data, CompressionLevel? level = null)
     {
-        byte[] newData;
         using (var memStream = new MemoryStream())
         {
+#if NET6_0_OR_GREATER
+            using(ZLibStream zlibStream = level.HasValue ? new(memStream, level.Value, true) : new(memStream, CompressionMode.Compress, true))
+            {
+                zlibStream.Write(data);
+            }
+#else
+
+            // Reference: https://yal.cc/cs-deflatestream-zlib/#code
+
             // write header:
             memStream.WriteByte(0x78);
-            switch (level)
+            memStream.WriteByte(level switch
             {
-                case CompressionLevel.NoCompression:
-                case CompressionLevel.Fastest:
-                    memStream.WriteByte(0x01);
-                    break;
-                case CompressionLevel.Optimal:
-                    memStream.WriteByte(0xDA);
-                    break;
-                default:
-                    memStream.WriteByte(0x9C);
-                    break;
-            }
+                CompressionLevel.NoCompression or CompressionLevel.Fastest => 0x01,
+                CompressionLevel.Optimal => 0x0A,
+                _ => 0x9C,
+            });
 
             // write compressed data (with Deflate headers):
-            using (var dflStream = level.HasValue
-                       ? new DeflateStream(memStream, level.Value)
-                       : new DeflateStream(memStream, CompressionMode.Compress
-                       )) dflStream.Write(data, 0, data.Length);
-            //
-            newData = memStream.ToArray();
+            using (DeflateStream dflStream = level.HasValue ? new(memStream, level.Value, true) : new(memStream, CompressionMode.Compress, true))
+            {
+                dflStream.Write(data, 0, data.Length);
+            }
+
+            // compute Adler-32:
+            uint a1 = 1, a2 = 0;
+            foreach (byte b in data)
+            {
+                a1 = (a1 + b) % 65521;
+                a2 = (a2 + a1) % 65521;
+            }
+
+            memStream.WriteByte((byte)(a2 >> 8));
+            memStream.WriteByte((byte)a2);
+            memStream.WriteByte((byte)(a1 >> 8));
+            memStream.WriteByte((byte)a1);
+
+#endif
+
+            return memStream.ToArray();
         }
 
-        // compute Adler-32:
-        uint a1 = 1, a2 = 0;
-        foreach (byte b in data)
-        {
-            a1 = (a1 + b) % 65521;
-            a2 = (a2 + a1) % 65521;
-        }
-
-        // append the checksum-trailer:
-        var adlerPos = newData.Length;
-        Array.Resize(ref newData, adlerPos + 4);
-        newData[adlerPos] = (byte)(a2 >> 8);
-        newData[adlerPos + 1] = (byte)a2;
-        newData[adlerPos + 2] = (byte)(a1 >> 8);
-        newData[adlerPos + 3] = (byte)a1;
-        return newData;
+        
     }
 
     public static void Main(string[] args)
     {
         var compressedBytes = Deflate(Encoding.UTF8.GetBytes("digraph G {Hello->World}"));
+#if NET9_0_OR_GREATER
+        // You can use this in previous version of .NET  with Microsoft.Bcl.Memory package
+        var encodedOutput = System.Buffers.Text.Base64Url.EncodeToString(compressedBytes);
+#else
         var encodedOutput = Convert.ToBase64String(compressedBytes).Replace('+', '-').Replace('/', '_');
+#endif
         Console.WriteLine($"https://kroki.io/graphviz/svg/{encodedOutput}");
     }
 }


### PR DESCRIPTION
- `ZLibStream` has been added in .NET 6.0
- `Base64Url` has been added in .NET 9.0
- Append the checksum-trailer to `MemoryStream` directly