### PR TITLE
Update D2 to 0.7.0 & add new C4 theme

### DIFF
--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -8,7 +8,7 @@ asciidoc:
     bpmn-version: 18.6.1
     bytefield-version: 1.11.0
     c4plantuml-version: 1.2025.0
-    d2-version: 0.6.9
+    d2-version: 0.7.0
     dbml-version: 1.0.30
     diagramsnet-version: 16.2.4
     ditaa-version: 1.0.3

--- a/server/ops/docker/jdk17-noble/Dockerfile
+++ b/server/ops/docker/jdk17-noble/Dockerfile
@@ -179,7 +179,7 @@ FROM ghcr.io/yuzutech/erd:v0.2.3 AS erd
 FROM eclipse-temurin:17.0.14_7-jre-noble
 
 ARG BLOCKDIAG_VERSION="3.1.0"
-ARG D2_VERSION="0.6.9"
+ARG D2_VERSION="0.7.0"
 ARG DITAA_VERSION="1.0.3"
 ARG DVISVGM_VERSION="3.2.1+ds-1build1"
 ARG GRAPHVIZ_VERSION="9.0.0"

--- a/server/src/main/java/io/kroki/server/service/D2.java
+++ b/server/src/main/java/io/kroki/server/service/D2.java
@@ -46,7 +46,8 @@ public class D2 implements DiagramService {
     entry("dark-flagship-terrastruct", 201),
     entry("terminal", 300),
     entry("terminal-grayscale", 301),
-    entry("origami", 302)
+    entry("origami", 302),
+    entry("c4", 303)
   );
 
   public D2(Vertx vertx, JsonObject config, Commander commander) {
@@ -73,7 +74,7 @@ public class D2 implements DiagramService {
 
   @Override
   public String getVersion() {
-    return "0.6.9";
+    return "0.7.0";
   }
 
   @Override


### PR DESCRIPTION
D2 recently released [v0.7.0 ](https://github.com/terrastruct/d2/releases/tag/v0.7.0) which adds much among others adds better support for c4 model diagrams. See https://d2lang.com/blog/c4 and a new c4 theme.

It would be great to have the new version in the next kroki release
