### PR TITLE
fix: set XDG_CONFIG_HOME and XDG_CACHE_HOME to temp directory

### DIFF
--- a/bpmn/Dockerfile
+++ b/bpmn/Dockerfile
@@ -17,6 +17,8 @@ ENV KROKI_BPMN_CONVERT_TIMEOUT=15000
 ENV PUPPETEER_EXECUTABLE_PATH=/usr/lib/chromium/chrome
 #ENV DEBUG="puppeteer:*"
 ENV LEVEL="info"
+ENV XDG_CONFIG_HOME="/tmp/config"
+ENV XDG_CACHE_HOME="/tmp/cache"
 
 COPY --chown=kroki:kroki src ./src
 COPY --chown=kroki:kroki package*.json ./

--- a/diagrams.net/Dockerfile
+++ b/diagrams.net/Dockerfile
@@ -17,6 +17,8 @@ ENV KROKI_DIAGRAMSNET_CONVERT_TIMEOUT=15000
 ENV PUPPETEER_EXECUTABLE_PATH=/usr/lib/chromium/chrome
 #ENV DEBUG="puppeteer:*"
 ENV LEVEL="info"
+ENV XDG_CONFIG_HOME="/tmp/config"
+ENV XDG_CACHE_HOME="/tmp/cache"
 
 COPY --chown=kroki:kroki src ./src
 COPY --chown=kroki:kroki package*.json ./

--- a/excalidraw/Dockerfile
+++ b/excalidraw/Dockerfile
@@ -24,6 +24,8 @@ ENV KROKI_EXCALIDRAW_ASSET_PATH=
 ENV PUPPETEER_EXECUTABLE_PATH=/usr/lib/chromium/chrome
 #ENV DEBUG="puppeteer:*"
 ENV LEVEL="info"
+ENV XDG_CONFIG_HOME="/tmp/config"
+ENV XDG_CACHE_HOME="/tmp/cache"
 
 COPY --chown=kroki:kroki src ./src
 COPY --chown=kroki:kroki package*.json ./

--- a/mermaid/Dockerfile
+++ b/mermaid/Dockerfile
@@ -19,6 +19,8 @@ ENV KROKI_MERMAID_PAGE_URL=file:///usr/local/kroki/assets/index.html
 ENV PUPPETEER_EXECUTABLE_PATH=/usr/lib/chromium/chrome
 #ENV DEBUG="puppeteer:*"
 ENV LEVEL="info"
+ENV XDG_CONFIG_HOME="/tmp/config"
+ENV XDG_CACHE_HOME="/tmp/cache"
 
 COPY --chown=kroki:kroki src ./src
 COPY --chown=kroki:kroki package*.json ./


### PR DESCRIPTION
Otherwise, Chrome cannot write files when running Docker in read-only.
Using `/tmp` directory seems like a good default value.

resolves #1910