### PR TITLE
Add the missing components of the plantuml-stdlib

### DIFF
--- a/server/src/main/java/io/kroki/server/service/Plantuml.java
+++ b/server/src/main/java/io/kroki/server/service/Plantuml.java
@@ -72,7 +72,7 @@ public class Plantuml implements DiagramService {
 
   private static final Logger logger = LoggerFactory.getLogger(Plantuml.class);
   private static final List<FileFormat> SUPPORTED_FORMATS = Arrays.asList(FileFormat.PNG, FileFormat.SVG, FileFormat.PDF, FileFormat.BASE64, FileFormat.TXT, FileFormat.UTXT);
-  private static final Pattern STDLIB_PATH_RX = Pattern.compile("<([a-zA-Z0-9]+)/[^>]+>");
+  private static final Pattern STDLIB_PATH_RX = Pattern.compile("<([-.a-zA-Z0-9]+)/[^>]+>");
 
   private final Vertx vertx;
   private final PlantumlCommand plantumlCommand;
@@ -110,7 +110,22 @@ public class Plantuml implements DiagramService {
     "material",
     "office",
     "osa",
-    "tupadr3");
+    "tupadr3",
+    "awslib",
+    "awslib10",
+    "awslib14",
+    "bootstrap",
+    "bootstrap1.12.1",
+    "bootstrap1.13.1",
+    "classy-c4",
+    "edgy",
+    "eip",
+    "gcp",
+    "k8s",
+    "material2.1.19",
+    "material7.4.47",
+    "osa2"
+    );
 
   public Plantuml(Vertx vertx, JsonObject config) {
     this.vertx = vertx;

--- a/server/src/test/java/io/kroki/server/service/PlantumlServiceTest.java
+++ b/server/src/test/java/io/kroki/server/service/PlantumlServiceTest.java
@@ -200,6 +200,21 @@ public class PlantumlServiceTest {
       "!include <office/Servers/database_server>\n" +
       "!include <osa/ai.puml>\n" +
       "!include <tupadr3/common>\n" +
+      "!include <archimate/Archimate>\n" +
+      "!include <awslib10/AWSCommon>\n" +
+      "!include <awslib14/AWSCommon>\n" +
+      "!include <bootstrap1.12.1/bootstrap>\n" +
+      "!include <bootstrap1.13.1/bootstrap>\n" +
+      "!include <classy-c4/person>\n" +
+      "!include <edgy/edgy>\n" +
+      "!include <eip/EIP-PlantUML>\n" +
+      "!include <elastic/common>\n" +
+      "!include <gcp/GCPCommon>\n" +
+      "!include <k8s/Simplified>\n" +
+      "!include <logos/100tb>\n" +
+      "!include <material2.1.19/account>\n" +
+      "!include <material7.4.47/material>\n" +
+      "!include <osa2/Common>\n" +
       "@enduml";
     String result = Plantuml.sanitize(diagram, SafeMode.SECURE);
     assertThat(result).isEqualTo(diagram + "\n");


### PR DESCRIPTION
* added the library components of the current plantuml-stdlib to the STDLIB path checking variable.
* changed the regex to include also dots and dashes in the path part.

Resolves #1914 