### PR TITLE
Send valid entity tags

### DIFF
--- a/server/src/main/java/io/kroki/server/response/Caching.java
+++ b/server/src/main/java/io/kroki/server/response/Caching.java
@@ -51,7 +51,10 @@ public class Caching {
     response.putHeader(HttpHeaders.DATE, httpDate(today));
     response.putHeader(HttpHeaders.LAST_MODIFIED, httpDate(compileTime));
     response.putHeader(HttpHeaders.CACHE_CONTROL, "public, max-age=" + maxAge);
-    response.putHeader(HttpHeaders.ETAG, version + internalEtag(data));
+    final String etag = internalEtag(data);
+    if (!"NOETAG".equals(etag)) {
+      response.putHeader(HttpHeaders.ETAG, "\"" + version + etag + "\"");
+    }
   }
 
   private String httpDate(long millis) {


### PR DESCRIPTION
The proposed change will send `"9.0.0CWmd-w-jCO5CZ4napfGmUm00"` instead of `9.0.0CWmd-w-jCO5CZ4napfGmUm00` in the ETAG header. If there is a failure to generate an ETAG, the header is not send.

The specification for the ETAG field is in https://datatracker.ietf.org/doc/html/rfc9110#name-etag. A valid entity tag must be surrounded by quotation marks. Furthermore, it doesn't make sense to send an entity tag that does not identify the ressource.

I have noticed the problem with the current entity tags generated by Kroki when I tried to set up caching and compression with HAProxy. HAProxy does not work as intended when the backend server sends invalid ETAG fields.