### PR TITLE
Fix bad tikz render due to bad documentclass

### DIFF
--- a/tikz/tikz2svg
+++ b/tikz/tikz2svg
@@ -34,7 +34,7 @@ backend_driver() {
             echo
             ;;
         svg)
-            echo dvisvgm,tikz
+            echo dvisvgm
             ;;
     esac
 }
@@ -59,7 +59,7 @@ documentclass_present() {
 
 infer_documentclass() {
     output_format=$1
-    echo "\\documentclass[$(backend_driver $output_format)]{standalone}"
+    echo "\\documentclass[tikz,$(backend_driver $output_format)]{standalone}"
 }
 
 add_documentclass() {

--- a/tikz/tikz2svg
+++ b/tikz/tikz2svg
@@ -62,13 +62,30 @@ infer_documentclass() {
     echo "\\documentclass[$(backend_driver $output_format)]{standalone}"
 }
 
-maybe_add_documentclass() {
+add_documentclass() {
+    documentclass=$1
+    raw_input=$2
+
+    echo $documentclass
+    cat $raw_input
+}
+
+replace_documentclass() {
+    documentclass=$1
+    raw_input=$2
+
+    sed "s/\\documentclass.*\\?}/$documentclass/" $raw_input
+}
+
+fixup_documentclass() {
     output_format=$1
     raw_input=$2
-    if ! documentclass_present $raw_input; then
-        infer_documentclass $output_format
+    documentclass=$(infer_documentclass $output_format)
+    if documentclass_present $raw_input; then
+        replace_documentclass $documentclass $raw_input
+    else
+        add_documentclass $documentclass $raw_input
     fi
-    cat $raw_input
 }
 
 output_format="$1"
@@ -90,7 +107,7 @@ cd $tempdir
 # Write stdin to raw_input.tex
 cat >raw_input.tex
 
-maybe_add_documentclass $output_format raw_input.tex > file.tex
+fixup_documentclass $output_format raw_input.tex > file.tex
 latex $LATEX_OPTIONS -output-format=$(intermediate_format $output_format) file.tex >/dev/null
 
 case "$output_format" in

--- a/tikz/tikz2svg
+++ b/tikz/tikz2svg
@@ -34,7 +34,7 @@ backend_driver() {
             echo
             ;;
         svg)
-            echo dvisvgm
+            echo dvisvgm,tikz
             ;;
     esac
 }


### PR DESCRIPTION
The tikz svg output uses dvisvgm.  Dvisvgm requires the input latex to specify the PGF dvisvgm driver by passing the dvisvgm option via the documentclass.

Previous to this change, the kroki tikz output would generate a correct documentclass if the user didn't provide one.  However, if the user provided a documentclass the kroki tikz output would use it as is.  This allowed users to specify an incorrect documentclass and then get undesired output.

Fix by overwriting any user-provided documentclass.  The implication is that users can no longer provide their own documentclass.  However, I couldn't find any convincing usecases for this in the context of diagrams.

This change implements option 1 from
https://github.com/yuzutech/kroki/issues/1870#issuecomment-2822066909. The alternative of surgically fixing up the user-provided documentclass instead of completely overwriting it was also considered but decided against due to complexity.  This alternative could be added later if a convincing usecase presents.

Example input that this change fixes:

```latex
\documentclass[margin=3mm]{standalone}
\usepackage{tikz}
\begin{document}
\begin{tikzpicture}
  \def\eggheight{3cm}
  \path[ball color=orange!60!gray]
  plot[domain=-pi:pi,samples=100]
  ({.78*\eggheight *cos(\x/4 r)*sin(\x r)},{-\eggheight*(cos(\x r))})
  -- cycle;
\end{tikzpicture}
\end{document}
```

Before this change:

![image](https://github.com/user-attachments/assets/b949610d-4a6c-4051-92c8-41affde0ff44)

After this change:

![image](https://github.com/user-attachments/assets/68efa7ce-9074-4186-9911-ec2bee1abad4)

Fixes #1870