### PR TITLE
Security: Reflected XSS in HTML error page rendering

### DIFF
--- a/server/src/main/resources/web/error.html
+++ b/server/src/main/resources/web/error.html
@@ -11,11 +11,11 @@
   <div class="container">
     <a href="https://kroki.io" target="_blank" rel="noopener noreferrer">{logo}</a>
     <h1 class="subtitle is-spaced">Convert <strong>plain text</strong> diagrams to <strong>images</strong> !</h1>
-    <h2 class="title">{title}</h2>
+    <h2 class="title">{titleEscaped}</h2>
     <article class="message is-danger">
       <div class="message-body">
-        <strong id="error"><code>{errorCode}</code> {errorMessage}</strong>
-        <ul id="stacktrace">{stackTrace}</ul>
+        <strong id="error"><code>{errorCodeEscaped}</code> {errorMessageEscaped}</strong>
+        <ul id="stacktrace">{stackTraceEscaped}</ul>
       </div>
     </article>
   </div>


### PR DESCRIPTION
## Problem

The error page template inserts `{errorMessage}` and `{stackTrace}` directly into HTML without escaping. Error messages can include untrusted content (for example, external tool stderr/stdout propagated through exceptions), which could execute script in a browser viewing the error page.

**Severity**: `high`
**File**: `server/src/main/resources/web/error.html`

## Solution

HTML-escape all dynamic values before template substitution (error message, stack trace, title, logo placeholders if dynamic). Prefer server-side templating with automatic escaping and only allow explicit safe HTML for tightly controlled fields.

## Changes

- `server/src/main/resources/web/error.html` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
