### PR TITLE
fix(ci): clean Puppeteer cache before installing Chrome for Mermaid tests

### DIFF
--- a/.github/workflows/mermaid-ci.yaml
+++ b/.github/workflows/mermaid-ci.yaml
@@ -22,8 +22,11 @@ jobs:
         with:
           node-version: 24
       - name: Install dependencies
+        run: npm i
+        working-directory: mermaid
+      - name: Install Chrome for Puppeteer
         run: |
-          npm i
+          rm -rf ~/.cache/puppeteer/chrome
           npx puppeteer browsers install chrome
         working-directory: mermaid
       - name: Lint & tests


### PR DESCRIPTION
The incomplete Chrome download created during `npm i` left a browser folder without an executable, causing `puppeteer browsers install chrome` to fail. Remove the cache directory first to force a clean install.