### PR TITLE
fix(ci): use a dedicated buildx cache directory per bake target

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -228,8 +228,9 @@ jobs:
       run: task dockerBuildImages
       env:
         BUILD_MULTIARCH: ${{ inputs.build_multiarch }}
-        CACHE_FROM: 'type=local,src=/tmp/.buildx-cache'
-        CACHE_TO: 'type=local,dest=/tmp/.buildx-cache-new'
+        # one cache subdirectory per bake target, see docker-bake.hcl
+        CACHE_FROM_DIR: '/tmp/.buildx-cache'
+        CACHE_TO_DIR: '/tmp/.buildx-cache-new'
 
     - name: 'Setup Node.js 24'
       uses: actions/setup-node@v6

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -22,7 +22,8 @@ tasks:
 
   dockerBuildImages:
     cmds:
-      - 'docker buildx bake --allow=fs.write=/tmp kroki companion-images {{if .BUILD_MULTIARCH}}--set "*.platform=linux/arm64,linux/amd64"{{end}} {{if .CACHE_FROM}}--set "*.cache-from={{.CACHE_FROM}}"{{end}} {{if .CACHE_TO}}--set "*.cache-to={{.CACHE_TO}}"{{end}}'
+      # the per-target cache locations are derived from the CACHE_FROM_DIR and CACHE_TO_DIR environment variables in docker-bake.hcl
+      - 'docker buildx bake --allow=fs=/tmp kroki companion-images {{if .BUILD_MULTIARCH}}--set "*.platform=linux/arm64,linux/amd64"{{end}}'
 
   dockerPublishImages:
     preconditions:
@@ -35,7 +36,7 @@ tasks:
     env:
       TAG: 'smoketests'
     cmds:
-      - 'docker buildx bake --allow=fs.write=/tmp kroki companion-images --load {{if .CACHE_FROM}}--set "*.cache-from={{.CACHE_FROM}}"{{end}} {{if .CACHE_TO}}--set "*.cache-to={{.CACHE_TO}}"{{end}}'
+      - 'docker buildx bake --allow=fs=/tmp kroki companion-images --load'
       - 'docker compose --file {{.TESTS_DIR}}/docker-compose.yaml up --build --detach'
       - defer: 'docker compose --file {{.TESTS_DIR}}/docker-compose.yaml stop'
       - 'echo'

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -2,6 +2,17 @@ variable "TAG" {
   default = "latest"
 }
 
+# Each target must use its own cache directory: concurrent cache exports
+# to the same local directory race in the ingest area and fail with
+# "error writing layer blob: rename tmp file ... no such file or directory".
+variable "CACHE_FROM_DIR" {
+  default = ""
+}
+
+variable "CACHE_TO_DIR" {
+  default = ""
+}
+
 group "companion-images" {
   targets = ["kroki-mermaid", "kroki-bpmn", "kroki-excalidraw", "kroki-diagramsnet"]
 }
@@ -27,6 +38,8 @@ target "kroki" {
   }
   dockerfile = "ops/docker/Dockerfile"
   tags = ["yuzutech/kroki:${TAG}"]
+  cache-from = CACHE_FROM_DIR != "" ? ["type=local,src=${CACHE_FROM_DIR}/kroki"] : []
+  cache-to = CACHE_TO_DIR != "" ? ["type=local,dest=${CACHE_TO_DIR}/kroki"] : []
   inherits = ["oci-labels"]
   labels = {
     "org.opencontainers.image.title" = "Kroki"
@@ -36,6 +49,8 @@ target "kroki" {
 target "kroki-mermaid" {
   context = "mermaid"
   tags = ["yuzutech/kroki-mermaid:${TAG}"]
+  cache-from = CACHE_FROM_DIR != "" ? ["type=local,src=${CACHE_FROM_DIR}/mermaid"] : []
+  cache-to = CACHE_TO_DIR != "" ? ["type=local,dest=${CACHE_TO_DIR}/mermaid"] : []
   inherits = ["oci-labels"]
   labels = {
     "org.opencontainers.image.title" = "Kroki - Mermaid"
@@ -45,6 +60,8 @@ target "kroki-mermaid" {
 target "kroki-bpmn" {
   context = "bpmn"
   tags = ["yuzutech/kroki-bpmn:${TAG}"]
+  cache-from = CACHE_FROM_DIR != "" ? ["type=local,src=${CACHE_FROM_DIR}/bpmn"] : []
+  cache-to = CACHE_TO_DIR != "" ? ["type=local,dest=${CACHE_TO_DIR}/bpmn"] : []
   inherits = ["oci-labels"]
   labels = {
     "org.opencontainers.image.title" = "Kroki - BPMN"
@@ -54,6 +71,8 @@ target "kroki-bpmn" {
 target "kroki-excalidraw" {
   context = "excalidraw"
   tags = ["yuzutech/kroki-excalidraw:${TAG}"]
+  cache-from = CACHE_FROM_DIR != "" ? ["type=local,src=${CACHE_FROM_DIR}/excalidraw"] : []
+  cache-to = CACHE_TO_DIR != "" ? ["type=local,dest=${CACHE_TO_DIR}/excalidraw"] : []
   inherits = ["oci-labels"]
   labels = {
     "org.opencontainers.image.title" = "Kroki - Excalidraw"
@@ -63,6 +82,8 @@ target "kroki-excalidraw" {
 target "kroki-diagramsnet" {
   context = "diagrams.net"
   tags = ["yuzutech/kroki-diagramsnet:${TAG}"]
+  cache-from = CACHE_FROM_DIR != "" ? ["type=local,src=${CACHE_FROM_DIR}/diagramsnet"] : []
+  cache-to = CACHE_TO_DIR != "" ? ["type=local,dest=${CACHE_TO_DIR}/diagramsnet"] : []
   inherits = ["oci-labels"]
   labels = {
     "org.opencontainers.image.title" = "Kroki - diagrams.net"


### PR DESCRIPTION
docker buildx bake builds the kroki and companion images in parallel and they all exported their cache to the same type=local directory. Concurrent cache exports race in the ingest area of the destination directory and randomly fail with "error writing layer blob: rename tmp file ... no such file or directory". Each bake target now derives its own cache subdirectory from the CACHE_FROM_DIR and CACHE_TO_DIR environment variables.