### PR TITLE
fix(companion): prevent browser leak and bound resource usage

### DIFF
--- a/diagrams.net/src/browser-instance.js
+++ b/diagrams.net/src/browser-instance.js
@@ -2,11 +2,23 @@ import puppeteer from 'puppeteer'
 
 import { logger } from './logger.js'
 
-let INSTANCE
+// Memoize the in-flight launch *promise* (not the resolved browser) so that
+// concurrent callers share a single Chrome instance. Storing the resolved value
+// left a window — between the first call entering the launch and it completing —
+// where every concurrent request launched its own browser, and only the last
+// one was ever tracked; the rest leaked (orphaned processes + RSS), and the leak
+// re-opened every time the instance was reset on crash.
+let INSTANCE_PROMISE
+
+// Cap how long a single CDP call may hang. Puppeteer's default protocolTimeout
+// is 180s: when Chrome gets wedged, calls outside any convert race would stall
+// for 3 minutes each, holding pages open and starving the service.
+const PROTOCOL_TIMEOUT = Number(process.env.KROKI_DIAGRAMSNET_PROTOCOL_TIMEOUT) || 30000
 
 const createBrowser = async () => {
   const browser = await puppeteer.launch({
     dumpio: true,
+    protocolTimeout: PROTOCOL_TIMEOUT,
     // reference: https://peter.sh/experiments/chromium-command-line-switches/
     args: [
       // allow to access files from file:// protocol
@@ -56,7 +68,7 @@ const createBrowser = async () => {
     logger.error({ code, signal }, 'chrome process exited')
     browserProcess.kill()
     browser.close()
-    INSTANCE = undefined
+    INSTANCE_PROMISE = undefined
   })
   browserProcess.on('message', message => {
     logger.warn({ message }, 'chrome process message')
@@ -72,9 +84,17 @@ const createBrowser = async () => {
 }
 
 export async function getBrowserWSEndpoint() {
-  if (INSTANCE === undefined) {
-    INSTANCE = await createBrowser()
-    logger.info(`Chrome accepting connections on endpoint ${INSTANCE.wsEndpoint()}`)
+  if (INSTANCE_PROMISE === undefined) {
+    INSTANCE_PROMISE = createBrowser()
+    INSTANCE_PROMISE.then(
+      browser => logger.info(`Chrome accepting connections on endpoint ${browser.wsEndpoint()}`),
+      // If the launch fails, drop the memoized rejected promise so the next
+      // request retries instead of being wedged on it forever.
+      () => {
+        INSTANCE_PROMISE = undefined
+      }
+    )
   }
-  return INSTANCE.wsEndpoint()
+  const browser = await INSTANCE_PROMISE
+  return browser.wsEndpoint()
 }

--- a/diagrams.net/src/worker.js
+++ b/diagrams.net/src/worker.js
@@ -128,7 +128,9 @@ export class Worker {
     const browserWSEndpoint = await getBrowserWSEndpoint()
     return await puppeteer.connect({
       browserWSEndpoint,
-      ignoreHTTPSErrors: true
+      ignoreHTTPSErrors: true,
+      // Bound CDP calls made outside any convert race (see browser-instance.js).
+      protocolTimeout: Number(process.env.KROKI_DIAGRAMSNET_PROTOCOL_TIMEOUT) || 30000
     })
   }
 }

--- a/docs/modules/setup/pages/configuration.adoc
+++ b/docs/modules/setup/pages/configuration.adoc
@@ -218,6 +218,59 @@ Currently, only PlantUML supports this configuration:
 Please note that this specific configuration will override `KROKI_CONVERT_TIMEOUT`.
 In other words, diagram library timeouts (for instance, `KROKI_PLANTUML_CONVERT_TIMEOUT`) have higher precedence than `KROKI_CONVERT_TIMEOUT`.
 
+== Delegate Timeout
+
+Diagrams handled by a companion container (Mermaid, BPMN, Excalidraw and diagrams.net) are delegated by the main Kroki server over HTTP.
+By default, the main server waits at most 30 seconds for the companion to respond before failing the request.
+
+Without such a limit, a slow or wedged companion would let requests pile up in the server until it runs out of memory.
+You can adjust this timeout with the `KROKI_DELEGATE_TIMEOUT_MS` environment variable (value in milliseconds):
+
+[source]
+----
+KROKI_DELEGATE_TIMEOUT_MS=30000 # default, 30 seconds
+----
+
+NOTE: The companions enforce their own convert timeout (10 seconds by default for Mermaid, see xref:mermaid-convert-timeout[] below).
+Keep `KROKI_DELEGATE_TIMEOUT_MS` slightly higher so the companion's structured error response is returned to the client instead of being cut short.
+
+== Companion Browser
+
+Mermaid, Excalidraw and diagrams.net render diagrams in a headless Chromium instance driven over the Chrome DevTools Protocol (CDP).
+
+=== Protocol Timeout
+
+To prevent a wedged browser from blocking a request for the Puppeteer default of 180 seconds, each CDP call is bounded.
+By default, a single CDP call may hang at most 30 seconds.
+You can adjust this per companion (value in milliseconds):
+
+[horizontal]
+`KROKI_MERMAID_PROTOCOL_TIMEOUT`:: Mermaid container (default: `30000`).
+`KROKI_DIAGRAMSNET_PROTOCOL_TIMEOUT`:: diagrams.net container (default: `30000`).
+`KROKI_EXCALIDRAW_PROTOCOL_TIMEOUT`:: Excalidraw container (default: `30000`).
+
+[#mermaid-convert-timeout]
+=== Mermaid Convert Timeout
+
+The Mermaid container aborts a single render that takes longer than 10 seconds and returns a `408` (Request Timeout) response status code.
+You can adjust this with the `KROKI_MERMAID_CONVERT_TIMEOUT` environment variable (value in milliseconds):
+
+[source]
+----
+KROKI_MERMAID_CONVERT_TIMEOUT=10000 # default, 10 seconds
+----
+
+=== Mermaid Diagram Limits
+
+To protect the service against resource exhaustion, the Mermaid container caps the size of a diagram:
+
+`KROKI_MERMAID_MAX_TEXT_SIZE`:: The maximum length, in characters, of a Mermaid diagram source.
+If the source exceeds this value, a `400` (Bad Request) response status code is sent. Defaults to `50000`.
+
+In addition, Mermaid's own edge limit (`maxEdges`, 500 by default) is enforced: a diagram with more edges is rejected with a `400` (Bad Request) response status code.
+
+NOTE: For security reasons, `maxTextSize`, `maxEdges`, `securityLevel`, `secure` and `startOnLoad` cannot be overridden per request through query parameters.
+
 == Companion Container Host and Port
 
 You can configure the host and port on which every companion container will be listening:

--- a/excalidraw/src/browser-instance.js
+++ b/excalidraw/src/browser-instance.js
@@ -2,10 +2,16 @@ import puppeteer from 'puppeteer'
 
 import { logger } from './logger.js'
 
+// Cap how long a single CDP call may hang. Puppeteer's default protocolTimeout
+// is 180s: when Chrome gets wedged, calls would stall for 3 minutes each,
+// holding pages open and starving the service.
+const PROTOCOL_TIMEOUT = Number(process.env.KROKI_EXCALIDRAW_PROTOCOL_TIMEOUT) || 30000
+
 const createBrowser = async () => {
   const browser = await puppeteer.launch({
     headless: 'new',
     dumpio: true,
+    protocolTimeout: PROTOCOL_TIMEOUT,
     args: [
       // Disables GPU hardware acceleration.
       // If software renderer is not in place, then the GPU process won't launch.

--- a/excalidraw/src/worker.js
+++ b/excalidraw/src/worker.js
@@ -15,7 +15,9 @@ export default class Worker {
   async convert(task) {
     const browser = await puppeteer.connect({
       browserWSEndpoint: this.browserWSEndpoint,
-      ignoreHTTPSErrors: true
+      ignoreHTTPSErrors: true,
+      // Bound CDP calls so a wedged Chrome fails fast instead of stalling 180s.
+      protocolTimeout: Number(process.env.KROKI_EXCALIDRAW_PROTOCOL_TIMEOUT) || 30000
     })
     const page = await browser.newPage()
     try {

--- a/mermaid/src/browser-instance.js
+++ b/mermaid/src/browser-instance.js
@@ -2,11 +2,24 @@ import puppeteer from 'puppeteer'
 
 import { logger } from './logger.js'
 
-let INSTANCE
+// Memoize the in-flight launch *promise* (not the resolved browser) so that
+// concurrent callers share a single Chrome instance. Storing the resolved
+// value instead left a window — between the first call entering the launch and
+// it completing — where every concurrent request launched its own browser, and
+// only the last one was ever tracked. The rest leaked (orphaned processes +
+// RSS) and the leak re-opened every time the instance was reset on crash.
+let INSTANCE_PROMISE
+
+// Cap how long a single CDP call may hang. Puppeteer's default protocolTimeout
+// is 180s: when Chrome gets wedged (e.g. a runaway render), calls outside the
+// convert race — newPage, goto, screenshot, close — would otherwise stall for
+// 3 minutes each, holding pages open and starving the service.
+const PROTOCOL_TIMEOUT = Number(process.env.KROKI_MERMAID_PROTOCOL_TIMEOUT) || 30000
 
 const createBrowser = async () => {
   const browser = await puppeteer.launch({
     dumpio: true,
+    protocolTimeout: PROTOCOL_TIMEOUT,
     // reference: https://peter.sh/experiments/chromium-command-line-switches/
     args: [
       // Disables GPU hardware acceleration.
@@ -54,7 +67,7 @@ const createBrowser = async () => {
     logger.error({ code, signal }, 'chrome process exited')
     browserProcess.kill()
     browser.close()
-    INSTANCE = undefined
+    INSTANCE_PROMISE = undefined
   })
   browserProcess.on('message', message => {
     logger.warn({ message }, 'chrome process message')
@@ -70,9 +83,17 @@ const createBrowser = async () => {
 }
 
 export async function getBrowserWSEndpoint() {
-  if (INSTANCE === undefined) {
-    INSTANCE = await createBrowser()
-    logger.info(`Chrome accepting connections on endpoint ${INSTANCE.wsEndpoint()}`)
+  if (INSTANCE_PROMISE === undefined) {
+    INSTANCE_PROMISE = createBrowser()
+    INSTANCE_PROMISE.then(
+      browser => logger.info(`Chrome accepting connections on endpoint ${browser.wsEndpoint()}`),
+      // If the launch fails, drop the memoized rejected promise so the next
+      // request retries instead of being wedged on it forever.
+      () => {
+        INSTANCE_PROMISE = undefined
+      }
+    )
   }
-  return INSTANCE.wsEndpoint()
+  const browser = await INSTANCE_PROMISE
+  return browser.wsEndpoint()
 }

--- a/mermaid/src/config.js
+++ b/mermaid/src/config.js
@@ -3,11 +3,14 @@ export function updateConfig(initialConfig, config) {
     const propertyCamelCase = convertPropertyToCamelCase(property)
     if (
       propertyCamelCase === 'maxTextSize' ||
+      propertyCamelCase === 'maxEdges' ||
       propertyCamelCase === 'securityLevel' ||
       propertyCamelCase === 'secure' ||
       propertyCamelCase === 'startOnLoad'
     ) {
-      // ignored for security reasons
+      // Ignored for security reasons: these caps protect the service from
+      // resource exhaustion. maxEdges/maxTextSize could later be opened up
+      // behind a "safe mode" toggle.
       continue
     }
     const value = getTypedValue(config.get(property))

--- a/mermaid/src/index.js
+++ b/mermaid/src/index.js
@@ -3,7 +3,7 @@ import { logger } from './logger.js'
 
 import http from 'node:http'
 import micro from 'micro'
-import { SyntaxError, TimeoutError, Worker } from './worker.js'
+import { MaxTextSizeError, SyntaxError, TimeoutError, Worker } from './worker.js'
 import Task from './task.js'
 
 ;(async () => {
@@ -40,6 +40,14 @@ import Task from './task.js'
                 error: {
                   message: `Request timeout: ${err.message}`,
                   name: 'TimeoutError',
+                  stacktrace: err.stack
+                }
+              })
+            } else if (err instanceof MaxTextSizeError) {
+              return micro.send(res, 400, {
+                error: {
+                  message: err.message,
+                  name: err.name,
                   stacktrace: err.stack
                 }
               })

--- a/mermaid/src/task.js
+++ b/mermaid/src/task.js
@@ -1,9 +1,16 @@
+// Hard cap on the diagram source length. mermaid renders an "Maximum text size
+// in diagram exceeded" *image* (HTTP 200) when its own maxTextSize is hit; we
+// set the same value here so we can reject oversized sources up front with a
+// 4xx instead (see worker.js). Non-overridable by the request (see config.js).
+export const MAX_TEXT_SIZE = Number(process.env.KROKI_MERMAID_MAX_TEXT_SIZE) || 50000
+
 export default class Task {
   constructor(source, isPng = false) {
     this.source = source
     this.isPng = isPng
     this.mermaidConfig = {
       theme: 'default',
+      maxTextSize: MAX_TEXT_SIZE,
       class: {
         useMaxWidth: false
       },

--- a/mermaid/src/worker.js
+++ b/mermaid/src/worker.js
@@ -23,6 +23,13 @@ export class SyntaxError extends Error {
   }
 }
 
+export class MaxTextSizeError extends Error {
+  constructor(actualSize, maxTextSize) {
+    super(`Diagram source is too large: ${actualSize} characters (maximum is ${maxTextSize})`)
+    this.name = 'MaxTextSizeError'
+  }
+}
+
 export class Worker {
   constructor() {
     this.pageUrl =
@@ -32,10 +39,17 @@ export class Worker {
   }
 
   async convert(task, config) {
+    const mermaidConfig = task.mermaidConfig
+    // Reject oversized sources up front: mermaid would otherwise resolve with an
+    // error *image* (HTTP 200) rather than failing. Done before spinning up a
+    // page so a flood of huge payloads can't tie up the browser.
+    const maxTextSize = mermaidConfig.maxTextSize
+    if (maxTextSize && task.source.length > maxTextSize) {
+      throw new MaxTextSizeError(task.source.length, maxTextSize)
+    }
     const browser = await this._connect()
     const page = await newPage(browser)
     try {
-      const mermaidConfig = task.mermaidConfig
       if (
         config !== null &&
         config !== undefined &&
@@ -125,7 +139,9 @@ export class Worker {
     const browserWSEndpoint = await getBrowserWSEndpoint()
     return await puppeteer.connect({
       browserWSEndpoint,
-      ignoreHTTPSErrors: true
+      ignoreHTTPSErrors: true,
+      // Bound CDP calls made outside the convert race (see browser-instance.js).
+      protocolTimeout: Number(process.env.KROKI_MERMAID_PROTOCOL_TIMEOUT) || 30000
     })
   }
 }

--- a/mermaid/test/config-test.mjs
+++ b/mermaid/test/config-test.mjs
@@ -42,4 +42,14 @@ describe('#updateConfig', function () {
     deepEqual(config.er.titleTopMargin, 10)
     deepEqual(config.securityLevel, undefined)
   })
+
+  it('should ignore attempts to raise resource caps (maxEdges, maxTextSize)', function () {
+    const config = {}
+    const urlSearchParams = new URLSearchParams()
+    urlSearchParams.set('max-edges', '500000')
+    urlSearchParams.set('max-text-size', '5000000')
+    updateConfig(config, urlSearchParams)
+    deepEqual(config.maxEdges, undefined)
+    deepEqual(config.maxTextSize, undefined)
+  })
 })

--- a/mermaid/test/convert-test.mjs
+++ b/mermaid/test/convert-test.mjs
@@ -120,6 +120,36 @@ describe('#convert', function () {
     })
   })
 
+  it('should throw MaxTextSizeError when the source exceeds maxTextSize', async function () {
+    // Oversized source is rejected up front, before connecting to a browser:
+    // mermaid would otherwise resolve with an error *image* (HTTP 200).
+    const source = `graph TD\n${'A-->B\n'.repeat(10000)}` // > 50000 chars
+    try {
+      await new Worker().convert(new Task(source))
+      fail('Should throw a MaxTextSizeError exception')
+    } catch (err) {
+      deepEqual(err.name, 'MaxTextSizeError')
+    }
+  })
+
+  invalidSyntaxTests.forEach((testCase) => {
+    it(`should throw syntax error when exceeding the edge limit in endpoint /${testCase.endpoint}`, async function () {
+      // The default maxEdges is 500 and cannot be raised per request (see config.js).
+      // mermaid throws on this one (unlike maxTextSize), so it surfaces as a SyntaxError.
+      const edges = Array.from({ length: 600 }, (_, i) => `n${i}-->n${i + 1}`).join('\n')
+      const source = `graph TD\n${edges}`
+      const browser = await getBrowser()
+      try {
+        await new Worker(browser).convert(new Task(source, testCase.isPng))
+        fail('Should throw a SyntaxError exception')
+      } catch (err) {
+        deepEqual(err.name, 'SyntaxError')
+      } finally {
+        await browser.close()
+      }
+    })
+  })
+
   it('should properly handle <> characters', async () => {
     `sequenceDiagram
     rect rgba(200, 150, 255, 0.2)

--- a/server/src/main/java/io/kroki/server/Server.java
+++ b/server/src/main/java/io/kroki/server/Server.java
@@ -63,7 +63,7 @@ public class Server extends AbstractVerticle {
     HttpServer server = vertx.createHttpServer(serverOptions);
     Router router = Router.router(vertx);
     BodyHandler bodyHandler = BodyHandler.create(false).setBodyLimit(config.getLong("KROKI_BODY_LIMIT", BodyHandler.DEFAULT_BODY_LIMIT));
-    Delegator delegator = new Delegator(vertx);
+    Delegator delegator = new Delegator(vertx, config);
     // CORS
     // CORS Headers
     Set<String> allowedHeaders = new LinkedHashSet<>();

--- a/server/src/main/java/io/kroki/server/action/Delegator.java
+++ b/server/src/main/java/io/kroki/server/action/Delegator.java
@@ -24,9 +24,20 @@ public class Delegator {
 
   private static final Logger logger = LoggerFactory.getLogger(Delegator.class);
   private static final Logging logging = new Logging(logger);
+  // Upstream companion services (mermaid, bpmn, ...) enforce their own convert
+  // timeout (10s by default). Allow a bit more so we receive their structured
+  // error response rather than cutting first, but never wait unbounded: without
+  // a timeout a wedged companion lets requests pile up in the client queue until
+  // the core runs out of memory.
+  private static final long DEFAULT_TIMEOUT_MS = 30_000;
   private final WebClient webClient;
+  private final long timeoutMs;
 
   public Delegator(Vertx vertx) {
+    this(vertx, new JsonObject());
+  }
+
+  public Delegator(Vertx vertx, JsonObject config) {
     HttpClient httpClient = vertx.httpClientBuilder()
       // https://vertx.io/docs/vertx-web-client/java/#_handling_30x_redirections
       // > By default the client follows redirections
@@ -36,11 +47,14 @@ public class Delegator {
       .withRedirectHandler(new AllowAnyMethodRedirectHandler())
       .build();
     this.webClient = WebClient.wrap(httpClient);
+    Long configured = config.getLong("KROKI_DELEGATE_TIMEOUT_MS");
+    this.timeoutMs = configured != null && configured > 0 ? configured : DEFAULT_TIMEOUT_MS;
   }
 
   public Future<HttpResponse<Buffer>> delegate(String host, int port, String requestURI, String body, JsonObject options) {
     HttpRequest<Buffer> request = this.webClient
       .post(port, host, requestURI)
+      .timeout(this.timeoutMs)
       .putHeader(HttpHeaders.ACCEPT.toString(), HttpHeaderValues.APPLICATION_JSON.toString());
     options.stream().iterator().forEachRemaining(entry -> {
       String key = entry.getKey();


### PR DESCRIPTION
Under concurrent load the companion containers could leak Chromium instances and let the core run out of memory. A cold-start burst of 12 requests launched 5 browsers instead of 1, leaving 4 orphaned (~4GB RSS that never came back).

Root cause: `getBrowserWSEndpoint` memoized the resolved browser, so every request entering the launch window before it completed started its own browser; only the last was tracked. The window re-opened on every crash (instance reset to undefined). Now memoize the in-flight *promise* so concurrent callers share a single launch, and reset it on failure/exit. Applied to mermaid and diagrams.net (same code); excalidraw creates its browser once at startup so it only needed the protocol-timeout change.

Also bound the failure modes that turned a slow companion into an OOM:
- Delegator now applies a timeout (default 30s, `KROKI_DELEGATE_TIMEOUT_MS`) so wedged companions can't pile requests up in the client queue.
- Puppeteer `protocolTimeout` capped at 30s (was 180s default) so CDP calls outside the convert race fail fast instead of holding pages open (`KROKI_{MERMAID,DIAGRAMSNET,EXCALIDRAW}_PROTOCOL_TIMEOUT`).

Mermaid input limits:
- `maxEdges` is no longer overridable via query param (joins maxTextSize), so a request can't lift the 500-edge cap and saturate the service. A later "safe mode" can reopen it. Exceeding it throws -> 400.
- Oversized sources now return 400 (`MaxTextSizeError`) instead of a 200 with an error image: the source length is checked up front, before a page is opened (`KROKI_MERMAID_MAX_TEXT_SIZE`, default 50000).

Documented the new variables in the Antora configuration page and added tests for the oversized-source, ignored-caps and edge-limit cases.


Resolves #2029 