### PR TITLE
refactor(companion): extract shared browser-instance library

### DIFF
--- a/.github/workflows/mermaid-ci.yaml
+++ b/.github/workflows/mermaid-ci.yaml
@@ -4,11 +4,13 @@ on:
   push:
     paths:
       - 'mermaid/**'
+      - 'lib/**'
     branches:
       - main
   pull_request:
     paths:
       - 'mermaid/**'
+      - 'lib/**'
     branches:
       - '*'
 

--- a/bpmn/Dockerfile
+++ b/bpmn/Dockerfile
@@ -24,6 +24,10 @@ COPY --chown=kroki:kroki src ./src
 COPY --chown=kroki:kroki package*.json ./
 COPY --chown=kroki:kroki assets ./assets
 
+# Shared package resolved through the file:../lib/browser-instance dependency
+# ("lib" named build context, see docker-bake.hcl)
+COPY --from=lib --chown=kroki:kroki . /usr/local/lib/browser-instance
+
 RUN npm i --omit=dev
 
 EXPOSE 8003

--- a/bpmn/package-lock.json
+++ b/bpmn/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "@kroki/browser-instance": "file:../lib/browser-instance",
         "bpmn-js": "18.18.0",
         "micro": "10.0.1",
         "pino": "9.14.0",
@@ -21,6 +22,11 @@
       "devDependencies": {
         "@biomejs/biome": "2.4.16"
       }
+    },
+    "../lib/browser-instance": {
+      "name": "@kroki/browser-instance",
+      "version": "1.0.0",
+      "license": "MIT"
     },
     "node_modules/@biomejs/biome": {
       "version": "2.4.16",
@@ -206,6 +212,10 @@
         "htm": "^3.1.1",
         "preact": "^10.29.2"
       }
+    },
+    "node_modules/@kroki/browser-instance": {
+      "resolved": "../lib/browser-instance",
+      "link": true
     },
     "node_modules/@pinojs/redact": {
       "version": "0.4.0",

--- a/bpmn/package.json
+++ b/bpmn/package.json
@@ -19,6 +19,7 @@
     "url": "https://github.com/yuzutech/kroki.git"
   },
   "dependencies": {
+    "@kroki/browser-instance": "file:../lib/browser-instance",
     "bpmn-js": "18.18.0",
     "micro": "10.0.1",
     "pino": "9.14.0",

--- a/bpmn/src/browser-instance.js
+++ b/bpmn/src/browser-instance.js
@@ -1,42 +1,14 @@
 import puppeteer from 'puppeteer'
+import { createBrowserInstance } from '@kroki/browser-instance'
 
-const createBrowser = async () => {
-  const browser = await puppeteer.launch({
-    args: [
-      // allow to access files from file:// protocol
-      '--allow-file-access-from-files',
-      // Disables GPU hardware acceleration.
-      // If software renderer is not in place, then the GPU process won't launch.
-      '--disable-gpu',
-      '--disable-translate',
-      // Disable the setuid sandbox (Linux only)
-      '--disable-setuid-sandbox',
-      // disable web security to access local files
-      '--disable-web-security',
-      // Run in headless mode, i.e., without a UI or display server dependencies
-      '--headless',
-      // Prevents creating scrollbars for web content. Useful for taking consistent screenshots.
-      '--hide-scrollbars',
-      // Mutes audio sent to the audio device, so it is not audible during automated testing.
-      '--mute-audio',
-      // Stops new Shell objects from navigating to a default url. ↪
-      '--no-initial-navigation',
-      // Disables the sandbox for all process types that are normally sandboxed.
-      // Meant to be used as a browser-level switch for testing purposes only.
-      '--no-sandbox',
-      '--disable-software-rasterizer'
-    ]
-  })
-  try {
-    return browser
-  } catch (err) {
-    await browser.close()
-    throw err
-  } finally {
-    await browser.disconnect()
-  }
-}
+import { logger } from './logger.js'
 
-export async function create() {
-  return createBrowser()
-}
+export const { getBrowserWSEndpoint, protocolTimeout } = createBrowserInstance({
+  puppeteer,
+  logger,
+  envPrefix: 'KROKI_BPMN',
+  extraArgs: [
+    // disable web security to access local files
+    '--disable-web-security'
+  ]
+})

--- a/bpmn/src/index.js
+++ b/bpmn/src/index.js
@@ -4,14 +4,14 @@ import http from 'node:http'
 import { TimeoutError as PuppeteerTimeoutError } from 'puppeteer'
 import micro from 'micro'
 import Task from './task.js'
-import { create } from './browser-instance.js'
+import { getBrowserWSEndpoint } from './browser-instance.js'
 import { SyntaxError, TimeoutError, Worker } from './worker.js'
 
 ;(async () => {
-  // QUESTION: should we create a pool of Chrome instances ?
-  const browser = await create()
-  logger.info(`Chrome accepting connections on endpoint ${browser.wsEndpoint()}`)
-  const worker = new Worker(browser)
+  // Warm up Chrome so the service fails fast when it cannot launch; the
+  // instance is re-created on demand if the process dies (see browser-instance.js).
+  await getBrowserWSEndpoint()
+  const worker = new Worker()
   const server = new http.Server(
     micro.serve(async (req, res) => {
       // TODO: add a /_status route (return bpmn version)

--- a/bpmn/src/worker.js
+++ b/bpmn/src/worker.js
@@ -3,6 +3,7 @@ import { URL, fileURLToPath } from 'node:url'
 import puppeteer from 'puppeteer'
 
 import { logger } from './logger.js'
+import { getBrowserWSEndpoint, protocolTimeout } from './browser-instance.js'
 
 const __dirname = fileURLToPath(new URL('.', import.meta.url))
 
@@ -20,8 +21,7 @@ export class SyntaxError extends Error {
 }
 
 export class Worker {
-  constructor(browserInstance) {
-    this.browserWSEndpoint = browserInstance.wsEndpoint()
+  constructor() {
     this.pageUrl =
       process.env.KROKI_BPMN_PAGE_URL ||
       `file://${path.join(__dirname, '..', 'assets', 'index.html')}`
@@ -30,8 +30,10 @@ export class Worker {
 
   async convert(task) {
     const browser = await puppeteer.connect({
-      browserWSEndpoint: this.browserWSEndpoint,
-      ignoreHTTPSErrors: true
+      browserWSEndpoint: await getBrowserWSEndpoint(),
+      ignoreHTTPSErrors: true,
+      // Bound CDP calls so a wedged Chrome fails fast instead of stalling 180s.
+      protocolTimeout
     })
     const page = await browser.newPage()
     try {

--- a/diagrams.net/Dockerfile
+++ b/diagrams.net/Dockerfile
@@ -24,6 +24,10 @@ COPY --chown=kroki:kroki src ./src
 COPY --chown=kroki:kroki package*.json ./
 COPY --chown=kroki:kroki assets ./assets
 
+# Shared package resolved through the file:../lib/browser-instance dependency
+# ("lib" named build context, see docker-bake.hcl)
+COPY --from=lib --chown=kroki:kroki . /usr/local/lib/browser-instance
+
 RUN npm i --omit=dev
 
 EXPOSE 8005

--- a/diagrams.net/package-lock.json
+++ b/diagrams.net/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "@kroki/browser-instance": "file:../lib/browser-instance",
         "micro": "10.0.1",
         "pino": "9.14.0",
         "pino-debug": "^2.0.0",
@@ -20,6 +21,11 @@
       "devDependencies": {
         "@biomejs/biome": "2.4.16"
       }
+    },
+    "../lib/browser-instance": {
+      "name": "@kroki/browser-instance",
+      "version": "1.0.0",
+      "license": "MIT"
     },
     "node_modules/@biomejs/biome": {
       "version": "2.4.16",
@@ -195,6 +201,10 @@
       "engines": {
         "node": ">=14.21.3"
       }
+    },
+    "node_modules/@kroki/browser-instance": {
+      "resolved": "../lib/browser-instance",
+      "link": true
     },
     "node_modules/@pinojs/redact": {
       "version": "0.4.0",

--- a/diagrams.net/package.json
+++ b/diagrams.net/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/yuzutech/kroki.git"
   },
   "dependencies": {
+    "@kroki/browser-instance": "file:../lib/browser-instance",
     "micro": "10.0.1",
     "pino": "9.14.0",
     "pino-debug": "^2.0.0",

--- a/diagrams.net/src/browser-instance.js
+++ b/diagrams.net/src/browser-instance.js
@@ -1,100 +1,14 @@
 import puppeteer from 'puppeteer'
+import { createBrowserInstance } from '@kroki/browser-instance'
 
 import { logger } from './logger.js'
 
-// Memoize the in-flight launch *promise* (not the resolved browser) so that
-// concurrent callers share a single Chrome instance. Storing the resolved value
-// left a window — between the first call entering the launch and it completing —
-// where every concurrent request launched its own browser, and only the last
-// one was ever tracked; the rest leaked (orphaned processes + RSS), and the leak
-// re-opened every time the instance was reset on crash.
-let INSTANCE_PROMISE
-
-// Cap how long a single CDP call may hang. Puppeteer's default protocolTimeout
-// is 180s: when Chrome gets wedged, calls outside any convert race would stall
-// for 3 minutes each, holding pages open and starving the service.
-const PROTOCOL_TIMEOUT = Number(process.env.KROKI_DIAGRAMSNET_PROTOCOL_TIMEOUT) || 30000
-
-const createBrowser = async () => {
-  const browser = await puppeteer.launch({
-    dumpio: true,
-    protocolTimeout: PROTOCOL_TIMEOUT,
-    // reference: https://peter.sh/experiments/chromium-command-line-switches/
-    args: [
-      // allow to access files from file:// protocol
-      '--allow-file-access-from-files',
-      // Disables GPU hardware acceleration.
-      // If software renderer is not in place, then the GPU process won't launch.
-      '--disable-gpu',
-      '--disable-translate',
-      // Disable the setuid sandbox (Linux only)
-      '--disable-setuid-sandbox',
-      // disable web security to access local files
-      '--disable-web-security',
-      // Run in headless mode, i.e., without a UI or display server dependencies
-      '--headless',
-      // Prevents creating scrollbars for web content. Useful for taking consistent screenshots.
-      '--hide-scrollbars',
-      // Mutes audio sent to the audio device, so it is not audible during automated testing.
-      '--mute-audio',
-      // Stops new Shell objects from navigating to a default url. ↪
-      '--no-initial-navigation',
-      // Disables the sandbox for all process types that are normally sandboxed.
-      // Meant to be used as a browser-level switch for testing purposes only.
-      '--no-sandbox',
-      '--disable-software-rasterizer'
-    ]
-  })
-  const browserProcess = browser.process()
-  logger.info(`Chrome instance launched with pid ${browserProcess.pid}`)
-
-  browserProcess.stdout.unpipe()
-  browserProcess.stderr.unpipe()
-  browserProcess.stdout.on('data', data => {
-    logger.debug({ stdout: data.toString() }, 'chrome process stdout')
-  })
-  browserProcess.stderr.on('data', data => {
-    logger.error({ stderr: data.toString() }, 'chrome process')
-  })
-  browserProcess.stdout.resume()
-  browserProcess.stderr.resume()
-  browserProcess.on('disconnect', () => {
-    logger.warn('chrome process disconnected')
-  })
-  browserProcess.on('error', err => {
-    logger.error({ err }, 'chrome process errored')
-  })
-  browserProcess.on('exit', (code, signal) => {
-    logger.error({ code, signal }, 'chrome process exited')
-    browserProcess.kill()
-    browser.close()
-    INSTANCE_PROMISE = undefined
-  })
-  browserProcess.on('message', message => {
-    logger.warn({ message }, 'chrome process message')
-  })
-  try {
-    return browser
-  } catch (err) {
-    await browser.close()
-    throw err
-  } finally {
-    await browser.disconnect()
-  }
-}
-
-export async function getBrowserWSEndpoint() {
-  if (INSTANCE_PROMISE === undefined) {
-    INSTANCE_PROMISE = createBrowser()
-    INSTANCE_PROMISE.then(
-      browser => logger.info(`Chrome accepting connections on endpoint ${browser.wsEndpoint()}`),
-      // If the launch fails, drop the memoized rejected promise so the next
-      // request retries instead of being wedged on it forever.
-      () => {
-        INSTANCE_PROMISE = undefined
-      }
-    )
-  }
-  const browser = await INSTANCE_PROMISE
-  return browser.wsEndpoint()
-}
+export const { getBrowserWSEndpoint, protocolTimeout } = createBrowserInstance({
+  puppeteer,
+  logger,
+  envPrefix: 'KROKI_DIAGRAMSNET',
+  extraArgs: [
+    // disable web security to access local files
+    '--disable-web-security'
+  ]
+})

--- a/diagrams.net/src/worker.js
+++ b/diagrams.net/src/worker.js
@@ -4,7 +4,7 @@ import { fileURLToPath, URL } from 'node:url'
 // eslint-disable-next-line
 import puppeteer, { Page } from 'puppeteer'
 import { logger } from './logger.js'
-import { getBrowserWSEndpoint } from './browser-instance.js'
+import { getBrowserWSEndpoint, protocolTimeout } from './browser-instance.js'
 
 const __dirname = fileURLToPath(new URL('.', import.meta.url))
 
@@ -130,7 +130,7 @@ export class Worker {
       browserWSEndpoint,
       ignoreHTTPSErrors: true,
       // Bound CDP calls made outside any convert race (see browser-instance.js).
-      protocolTimeout: Number(process.env.KROKI_DIAGRAMSNET_PROTOCOL_TIMEOUT) || 30000
+      protocolTimeout
     })
   }
 }

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -48,6 +48,9 @@ target "kroki" {
 
 target "kroki-mermaid" {
   context = "mermaid"
+  contexts = {
+    lib = "./lib/browser-instance"
+  }
   tags = ["yuzutech/kroki-mermaid:${TAG}"]
   cache-from = CACHE_FROM_DIR != "" ? ["type=local,src=${CACHE_FROM_DIR}/mermaid"] : []
   cache-to = CACHE_TO_DIR != "" ? ["type=local,dest=${CACHE_TO_DIR}/mermaid"] : []
@@ -59,6 +62,9 @@ target "kroki-mermaid" {
 
 target "kroki-bpmn" {
   context = "bpmn"
+  contexts = {
+    lib = "./lib/browser-instance"
+  }
   tags = ["yuzutech/kroki-bpmn:${TAG}"]
   cache-from = CACHE_FROM_DIR != "" ? ["type=local,src=${CACHE_FROM_DIR}/bpmn"] : []
   cache-to = CACHE_TO_DIR != "" ? ["type=local,dest=${CACHE_TO_DIR}/bpmn"] : []
@@ -70,6 +76,9 @@ target "kroki-bpmn" {
 
 target "kroki-excalidraw" {
   context = "excalidraw"
+  contexts = {
+    lib = "./lib/browser-instance"
+  }
   tags = ["yuzutech/kroki-excalidraw:${TAG}"]
   cache-from = CACHE_FROM_DIR != "" ? ["type=local,src=${CACHE_FROM_DIR}/excalidraw"] : []
   cache-to = CACHE_TO_DIR != "" ? ["type=local,dest=${CACHE_TO_DIR}/excalidraw"] : []
@@ -81,6 +90,9 @@ target "kroki-excalidraw" {
 
 target "kroki-diagramsnet" {
   context = "diagrams.net"
+  contexts = {
+    lib = "./lib/browser-instance"
+  }
   tags = ["yuzutech/kroki-diagramsnet:${TAG}"]
   cache-from = CACHE_FROM_DIR != "" ? ["type=local,src=${CACHE_FROM_DIR}/diagramsnet"] : []
   cache-to = CACHE_TO_DIR != "" ? ["type=local,dest=${CACHE_TO_DIR}/diagramsnet"] : []

--- a/excalidraw/Dockerfile
+++ b/excalidraw/Dockerfile
@@ -1,5 +1,11 @@
 FROM node:24.16-alpine3.23 AS builder
 
+WORKDIR /usr/local/kroki/
+
+# Shared package resolved through the file:../lib/browser-instance dependency
+# ("lib" named build context, see docker-bake.hcl)
+COPY --from=lib . /usr/local/lib/browser-instance
+
 COPY assets ./assets
 COPY package*.json ./
 
@@ -30,7 +36,11 @@ ENV XDG_CACHE_HOME="/tmp/cache"
 COPY --chown=kroki:kroki src ./src
 COPY --chown=kroki:kroki package*.json ./
 COPY --chown=kroki:kroki assets ./assets
-COPY --from=builder --chown=kroki:kroki ./assets/index.bundle.js ./assets/index.bundle.js
+COPY --from=builder --chown=kroki:kroki /usr/local/kroki/assets/index.bundle.js ./assets/index.bundle.js
+
+# Shared package resolved through the file:../lib/browser-instance dependency
+# ("lib" named build context, see docker-bake.hcl)
+COPY --from=lib --chown=kroki:kroki . /usr/local/lib/browser-instance
 
 RUN npm i --omit=dev
 

--- a/excalidraw/package-lock.json
+++ b/excalidraw/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@excalidraw/excalidraw": "0.18.1",
+        "@kroki/browser-instance": "file:../lib/browser-instance",
         "micro": "10.0.1",
         "pino": "9.14.0",
         "pino-debug": "2.0.0",
@@ -24,6 +25,11 @@
         "@biomejs/biome": "2.4.16",
         "esbuild": "0.28.0"
       }
+    },
+    "../lib/browser-instance": {
+      "name": "@kroki/browser-instance",
+      "version": "1.0.0",
+      "license": "MIT"
     },
     "node_modules/@antfu/install-pkg": {
       "version": "1.1.0",
@@ -857,6 +863,10 @@
         "@iconify/types": "^2.0.0",
         "import-meta-resolve": "^4.2.0"
       }
+    },
+    "node_modules/@kroki/browser-instance": {
+      "resolved": "../lib/browser-instance",
+      "link": true
     },
     "node_modules/@mermaid-js/parser": {
       "version": "0.6.3",

--- a/excalidraw/package.json
+++ b/excalidraw/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "@excalidraw/excalidraw": "0.18.1",
+    "@kroki/browser-instance": "file:../lib/browser-instance",
     "micro": "10.0.1",
     "pino": "9.14.0",
     "pino-debug": "2.0.0",

--- a/excalidraw/src/browser-instance.js
+++ b/excalidraw/src/browser-instance.js
@@ -1,73 +1,10 @@
 import puppeteer from 'puppeteer'
+import { createBrowserInstance } from '@kroki/browser-instance'
 
 import { logger } from './logger.js'
 
-// Cap how long a single CDP call may hang. Puppeteer's default protocolTimeout
-// is 180s: when Chrome gets wedged, calls would stall for 3 minutes each,
-// holding pages open and starving the service.
-const PROTOCOL_TIMEOUT = Number(process.env.KROKI_EXCALIDRAW_PROTOCOL_TIMEOUT) || 30000
-
-const createBrowser = async () => {
-  const browser = await puppeteer.launch({
-    headless: 'new',
-    dumpio: true,
-    protocolTimeout: PROTOCOL_TIMEOUT,
-    args: [
-      // Disables GPU hardware acceleration.
-      // If software renderer is not in place, then the GPU process won't launch.
-      '--disable-gpu',
-      '--disable-translate',
-      // Disable the setuid sandbox (Linux only)
-      '--disable-setuid-sandbox',
-      // Run in headless mode, i.e., without a UI or display server dependencies
-      '--headless',
-      // Prevents creating scrollbars for web content. Useful for taking consistent screenshots.
-      '--hide-scrollbars',
-      // Mutes audio sent to the audio device, so it is not audible during automated testing.
-      '--mute-audio',
-      // Stops new Shell objects from navigating to a default url. ↪
-      '--no-initial-navigation',
-      // Disables the sandbox for all process types that are normally sandboxed.
-      // Meant to be used as a browser-level switch for testing purposes only.
-      '--no-sandbox',
-      // import modules from file://
-      '--allow-file-access-from-files'
-    ]
-  })
-
-  const browserProcess = browser.process()
-  browserProcess.stdout.unpipe()
-  browserProcess.stderr.unpipe()
-  browserProcess.stdout.on('data', data => {
-    logger.debug({ stdout: data.toString() }, 'chrome process stdout')
-  })
-  browserProcess.stderr.on('data', data => {
-    logger.error({ stderr: data.toString() }, 'chrome process')
-  })
-  browserProcess.stdout.resume()
-  browserProcess.stderr.resume()
-  browserProcess.on('disconnect', () => {
-    logger.warn('chrome process disconnected')
-  })
-  browserProcess.on('error', err => {
-    logger.error({ err }, 'chrome process errored')
-  })
-  browserProcess.on('exit', (code, signal) => {
-    logger.error({ code, signal }, 'chrome process exited')
-  })
-  browserProcess.on('message', message => {
-    logger.warn({ message }, 'chrome process message')
-  })
-  try {
-    return browser
-  } catch (err) {
-    await browser.close()
-    throw err
-  } finally {
-    browser.disconnect()
-  }
-}
-
-export async function create() {
-  return createBrowser()
-}
+export const { getBrowserWSEndpoint, protocolTimeout } = createBrowserInstance({
+  puppeteer,
+  logger,
+  envPrefix: 'KROKI_EXCALIDRAW'
+})

--- a/excalidraw/src/index.js
+++ b/excalidraw/src/index.js
@@ -6,13 +6,13 @@ import fsp from 'node:fs/promises'
 import micro from 'micro'
 import Worker from './worker.js'
 import Task from './task.js'
-import { create } from './browser-instance.js'
+import { getBrowserWSEndpoint } from './browser-instance.js'
 
 ;(async () => {
-  // QUESTION: should we create a pool of Chrome instances ?
-  const browser = await create()
-  logger.info(`Chrome accepting connections on endpoint ${browser.wsEndpoint()}`)
-  const worker = new Worker(browser)
+  // Warm up Chrome so the service fails fast when it cannot launch; the
+  // instance is re-created on demand if the process dies (see browser-instance.js).
+  await getBrowserWSEndpoint()
+  const worker = new Worker()
   const server = new http.Server(
     micro.serve(async (req, res) => {
       const url = new URL(req.url, 'http://localhost') // create a URL object. The base is not important here

--- a/excalidraw/src/worker.js
+++ b/excalidraw/src/worker.js
@@ -1,12 +1,12 @@
 import { URL, fileURLToPath } from 'node:url'
 import puppeteer from 'puppeteer'
 import { logger } from './logger.js'
+import { getBrowserWSEndpoint, protocolTimeout } from './browser-instance.js'
 
 const __dirname = fileURLToPath(new URL('.', import.meta.url))
 
 export default class Worker {
-  constructor(browserInstance) {
-    this.browserWSEndpoint = browserInstance.wsEndpoint()
+  constructor() {
     this.pageUrl =
       process.env.KROKI_EXCALIDRAW_PAGE_URL || 'http://127.0.0.1:8004/public/index.html'
     this.assetPath = process.env.KROKI_EXCALIDRAW_ASSET_PATH || '/public'
@@ -14,10 +14,10 @@ export default class Worker {
 
   async convert(task) {
     const browser = await puppeteer.connect({
-      browserWSEndpoint: this.browserWSEndpoint,
+      browserWSEndpoint: await getBrowserWSEndpoint(),
       ignoreHTTPSErrors: true,
       // Bound CDP calls so a wedged Chrome fails fast instead of stalling 180s.
-      protocolTimeout: Number(process.env.KROKI_EXCALIDRAW_PROTOCOL_TIMEOUT) || 30000
+      protocolTimeout
     })
     const page = await browser.newPage()
     try {

--- a/lib/browser-instance/index.js
+++ b/lib/browser-instance/index.js
@@ -1,0 +1,114 @@
+// Shared Chrome instance manager for the Kroki companion services
+// (mermaid, diagrams.net, bpmn, excalidraw).
+//
+// This package is consumed as a `file:` dependency, which npm installs as a
+// symlink: Node resolves imports from the package's *real* location, outside
+// the service directory, so nothing from the service node_modules would be
+// visible here. It therefore has zero dependencies — the service injects its
+// own puppeteer module and logger.
+
+// reference: https://peter.sh/experiments/chromium-command-line-switches/
+const BASE_ARGS = [
+  // import modules and access files from file://
+  '--allow-file-access-from-files',
+  // Disables GPU hardware acceleration.
+  // If software renderer is not in place, then the GPU process won't launch.
+  '--disable-gpu',
+  '--disable-software-rasterizer',
+  '--disable-translate',
+  // Disable the setuid sandbox (Linux only)
+  '--disable-setuid-sandbox',
+  // Run in headless mode, i.e., without a UI or display server dependencies
+  '--headless',
+  // Prevents creating scrollbars for web content. Useful for taking consistent screenshots.
+  '--hide-scrollbars',
+  // Mutes audio sent to the audio device, so it is not audible during automated testing.
+  '--mute-audio',
+  // Stops new Shell objects from navigating to a default url. ↪
+  '--no-initial-navigation',
+  // Disables the sandbox for all process types that are normally sandboxed.
+  // Meant to be used as a browser-level switch for testing purposes only.
+  '--no-sandbox'
+]
+
+/**
+ * @param {object} options
+ * @param {object} options.puppeteer - the puppeteer module of the service
+ * @param {object} options.logger - a pino-compatible logger
+ * @param {string} options.envPrefix - e.g. 'KROKI_MERMAID'; used to read `${envPrefix}_PROTOCOL_TIMEOUT`
+ * @param {string[]} [options.extraArgs] - service-specific Chrome flags appended to the base set
+ * @returns {{getBrowserWSEndpoint: () => Promise<string>, protocolTimeout: number}}
+ */
+export function createBrowserInstance({ puppeteer, logger, envPrefix, extraArgs = [] }) {
+  // Cap how long a single CDP call may hang. Puppeteer's default protocolTimeout
+  // is 180s: when Chrome gets wedged (e.g. a runaway render), calls outside the
+  // convert race — newPage, goto, screenshot, close — would otherwise stall for
+  // 3 minutes each, holding pages open and starving the service.
+  const protocolTimeout = Number(process.env[`${envPrefix}_PROTOCOL_TIMEOUT`]) || 30000
+
+  // Memoize the in-flight launch *promise* (not the resolved browser) so that
+  // concurrent callers share a single Chrome instance. Storing the resolved
+  // value instead left a window — between the first call entering the launch and
+  // it completing — where every concurrent request launched its own browser, and
+  // only the last one was ever tracked. The rest leaked (orphaned processes +
+  // RSS) and the leak re-opened every time the instance was reset on crash.
+  let instancePromise
+
+  const createBrowser = async () => {
+    const browser = await puppeteer.launch({
+      dumpio: true,
+      protocolTimeout,
+      args: [...BASE_ARGS, ...extraArgs]
+    })
+    const browserProcess = browser.process()
+    logger.info(`Chrome instance launched with pid ${browserProcess.pid}`)
+
+    browserProcess.stdout.unpipe()
+    browserProcess.stderr.unpipe()
+    browserProcess.stdout.on('data', data => {
+      logger.debug({ stdout: data.toString() }, 'chrome process stdout')
+    })
+    browserProcess.stderr.on('data', data => {
+      logger.error({ stderr: data.toString() }, 'chrome process')
+    })
+    browserProcess.stdout.resume()
+    browserProcess.stderr.resume()
+    browserProcess.on('disconnect', () => {
+      logger.warn('chrome process disconnected')
+    })
+    browserProcess.on('error', err => {
+      logger.error({ err }, 'chrome process errored')
+    })
+    browserProcess.on('exit', (code, signal) => {
+      logger.error({ code, signal }, 'chrome process exited')
+      browserProcess.kill()
+      browser.close()
+      instancePromise = undefined
+    })
+    browserProcess.on('message', message => {
+      logger.warn({ message }, 'chrome process message')
+    })
+    // The launcher client disconnects once the browser is up: workers connect
+    // (and disconnect) per request over the WebSocket endpoint.
+    await browser.disconnect()
+    return browser
+  }
+
+  async function getBrowserWSEndpoint() {
+    if (instancePromise === undefined) {
+      instancePromise = createBrowser()
+      instancePromise.then(
+        browser => logger.info(`Chrome accepting connections on endpoint ${browser.wsEndpoint()}`),
+        // If the launch fails, drop the memoized rejected promise so the next
+        // request retries instead of being wedged on it forever.
+        () => {
+          instancePromise = undefined
+        }
+      )
+    }
+    const browser = await instancePromise
+    return browser.wsEndpoint()
+  }
+
+  return { getBrowserWSEndpoint, protocolTimeout }
+}

--- a/lib/browser-instance/package.json
+++ b/lib/browser-instance/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@kroki/browser-instance",
+  "version": "1.0.0",
+  "description": "Shared Chrome instance manager for the Kroki companion services.",
+  "main": "index.js",
+  "type": "module",
+  "keywords": [],
+  "author": "Guillaume Grossetie",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/yuzutech/kroki.git"
+  }
+}

--- a/mermaid/Dockerfile
+++ b/mermaid/Dockerfile
@@ -26,6 +26,10 @@ COPY --chown=kroki:kroki src ./src
 COPY --chown=kroki:kroki package*.json ./
 COPY --chown=kroki:kroki assets ./assets
 
+# Shared package resolved through the file:../lib/browser-instance dependency
+# ("lib" named build context, see docker-bake.hcl)
+COPY --from=lib --chown=kroki:kroki . /usr/local/lib/browser-instance
+
 RUN npm i --omit=dev
 
 EXPOSE 8002

--- a/mermaid/package-lock.json
+++ b/mermaid/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "@kroki/browser-instance": "file:../lib/browser-instance",
         "micro": "10.0.1",
         "pino": "9.14.0",
         "pino-debug": "2.0.0",
@@ -22,6 +23,11 @@
         "mermaid": "11.15.0",
         "pngjs": "7.0.0"
       }
+    },
+    "../lib/browser-instance": {
+      "name": "@kroki/browser-instance",
+      "version": "1.0.0",
+      "license": "MIT"
     },
     "node_modules/@antfu/install-pkg": {
       "version": "1.1.0",
@@ -244,6 +250,10 @@
         "@iconify/types": "^2.0.0",
         "mlly": "^1.8.0"
       }
+    },
+    "node_modules/@kroki/browser-instance": {
+      "resolved": "../lib/browser-instance",
+      "link": true
     },
     "node_modules/@mermaid-js/parser": {
       "version": "1.1.1",

--- a/mermaid/package.json
+++ b/mermaid/package.json
@@ -19,14 +19,15 @@
     "url": "https://github.com/yuzutech/kroki.git"
   },
   "dependencies": {
+    "@kroki/browser-instance": "file:../lib/browser-instance",
     "micro": "10.0.1",
     "pino": "9.14.0",
     "pino-debug": "2.0.0",
     "puppeteer": "25.1.0"
   },
   "devDependencies": {
-    "mermaid": "11.15.0",
     "@biomejs/biome": "2.4.16",
+    "mermaid": "11.15.0",
     "pngjs": "7.0.0"
   },
   "volta": {

--- a/mermaid/src/browser-instance.js
+++ b/mermaid/src/browser-instance.js
@@ -1,99 +1,10 @@
 import puppeteer from 'puppeteer'
+import { createBrowserInstance } from '@kroki/browser-instance'
 
 import { logger } from './logger.js'
 
-// Memoize the in-flight launch *promise* (not the resolved browser) so that
-// concurrent callers share a single Chrome instance. Storing the resolved
-// value instead left a window — between the first call entering the launch and
-// it completing — where every concurrent request launched its own browser, and
-// only the last one was ever tracked. The rest leaked (orphaned processes +
-// RSS) and the leak re-opened every time the instance was reset on crash.
-let INSTANCE_PROMISE
-
-// Cap how long a single CDP call may hang. Puppeteer's default protocolTimeout
-// is 180s: when Chrome gets wedged (e.g. a runaway render), calls outside the
-// convert race — newPage, goto, screenshot, close — would otherwise stall for
-// 3 minutes each, holding pages open and starving the service.
-const PROTOCOL_TIMEOUT = Number(process.env.KROKI_MERMAID_PROTOCOL_TIMEOUT) || 30000
-
-const createBrowser = async () => {
-  const browser = await puppeteer.launch({
-    dumpio: true,
-    protocolTimeout: PROTOCOL_TIMEOUT,
-    // reference: https://peter.sh/experiments/chromium-command-line-switches/
-    args: [
-      // Disables GPU hardware acceleration.
-      // If software renderer is not in place, then the GPU process won't launch.
-      '--disable-gpu',
-      '--disable-translate',
-      // Disable the setuid sandbox (Linux only)
-      '--disable-setuid-sandbox',
-      // Run in headless mode, i.e., without a UI or display server dependencies
-      '--headless',
-      // Prevents creating scrollbars for web content. Useful for taking consistent screenshots.
-      '--hide-scrollbars',
-      // Mutes audio sent to the audio device, so it is not audible during automated testing.
-      '--mute-audio',
-      // Stops new Shell objects from navigating to a default url. ↪
-      '--no-initial-navigation',
-      // Disables the sandbox for all process types that are normally sandboxed.
-      // Meant to be used as a browser-level switch for testing purposes only.
-      '--no-sandbox',
-      // import modules from file://
-      '--allow-file-access-from-files',
-      '--disable-software-rasterizer'
-    ]
-  })
-  const browserProcess = browser.process()
-  logger.info(`Chrome instance launched with pid ${browserProcess.pid}`)
-
-  browserProcess.stdout.unpipe()
-  browserProcess.stderr.unpipe()
-  browserProcess.stdout.on('data', data => {
-    logger.debug({ stdout: data.toString() }, 'chrome process stdout')
-  })
-  browserProcess.stderr.on('data', data => {
-    logger.error({ stderr: data.toString() }, 'chrome process')
-  })
-  browserProcess.stdout.resume()
-  browserProcess.stderr.resume()
-  browserProcess.on('disconnect', () => {
-    logger.warn('chrome process disconnected')
-  })
-  browserProcess.on('error', err => {
-    logger.error({ err }, 'chrome process errored')
-  })
-  browserProcess.on('exit', (code, signal) => {
-    logger.error({ code, signal }, 'chrome process exited')
-    browserProcess.kill()
-    browser.close()
-    INSTANCE_PROMISE = undefined
-  })
-  browserProcess.on('message', message => {
-    logger.warn({ message }, 'chrome process message')
-  })
-  try {
-    return browser
-  } catch (err) {
-    await browser.close()
-    throw err
-  } finally {
-    await browser.disconnect()
-  }
-}
-
-export async function getBrowserWSEndpoint() {
-  if (INSTANCE_PROMISE === undefined) {
-    INSTANCE_PROMISE = createBrowser()
-    INSTANCE_PROMISE.then(
-      browser => logger.info(`Chrome accepting connections on endpoint ${browser.wsEndpoint()}`),
-      // If the launch fails, drop the memoized rejected promise so the next
-      // request retries instead of being wedged on it forever.
-      () => {
-        INSTANCE_PROMISE = undefined
-      }
-    )
-  }
-  const browser = await INSTANCE_PROMISE
-  return browser.wsEndpoint()
-}
+export const { getBrowserWSEndpoint, protocolTimeout } = createBrowserInstance({
+  puppeteer,
+  logger,
+  envPrefix: 'KROKI_MERMAID'
+})

--- a/mermaid/src/worker.js
+++ b/mermaid/src/worker.js
@@ -4,7 +4,7 @@ import path from 'node:path'
 import puppeteer, { HTTPResponse, Page } from 'puppeteer'
 import { logger } from './logger.js'
 import { updateConfig } from './config.js'
-import { getBrowserWSEndpoint } from './browser-instance.js'
+import { getBrowserWSEndpoint, protocolTimeout } from './browser-instance.js'
 
 const __dirname = fileURLToPath(new URL('.', import.meta.url))
 
@@ -141,7 +141,7 @@ export class Worker {
       browserWSEndpoint,
       ignoreHTTPSErrors: true,
       // Bound CDP calls made outside the convert race (see browser-instance.js).
-      protocolTimeout: Number(process.env.KROKI_MERMAID_PROTOCOL_TIMEOUT) || 30000
+      protocolTimeout
     })
   }
 }


### PR DESCRIPTION
Extract the Chrome instance management duplicated across mermaid, diagrams.net, bpmn and excalidraw into lib/browser-instance, consumed as a file: dependency. The library has zero dependencies on purpose: npm installs file: packages as symlinks, so imports resolve from the package's real location, outside the service `node_modules` — each service injects its own puppeteer module and logger instead.

Each service keeps a thin `src/browser-instance.js` shim that declares its divergence explicitly (env prefix, extra Chrome flags such as `--disable-web-security` for diagrams.net and bpmn).

This also ports the browser leak fix to bpmn and excalidraw, which were still launching Chrome once at startup with no recovery when the process died: they now use the memoized launch promise, relaunch on demand, bound CDP calls with protocolTimeout and route the Chrome process output to the logger.

Docker builds resolve the library through a named "lib" build context in `docker-bake.hcl`, copied to `/usr/local/lib/browser-instance` so the `file:../lib/browser-instance` dependency resolves identically locally and in the image. Note that the companion images now require buildx bake (a plain docker build lacks the named context).