### PR TITLE
ci: replace arduino/setup-task with go-task/setup-task

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -196,7 +196,7 @@ jobs:
         distribution: temurin
 
     - name: Install Task
-      uses: arduino/setup-task@v2
+      uses: go-task/setup-task@v2
       with:
         version: 3.x
         repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
           java-version: 21
           distribution: temurin
       - name: Install Task
-        uses: arduino/setup-task@v2
+        uses: go-task/setup-task@v2
         with:
           version: 3.x
           repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -270,7 +270,7 @@ jobs:
           java-version: 21
           distribution: temurin
       - name: Install Task
-        uses: arduino/setup-task@v2
+        uses: go-task/setup-task@v2
         with:
           version: 3.x
           repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The official go-task/setup-task action runs on Node.js 24, fixing the Node.js 20 deprecation warning on GitHub Actions runners.