### PR TITLE
fix(goat): preserve leading whitespace of the first line

### DIFF
--- a/server/src/main/java/io/kroki/server/service/Goat.java
+++ b/server/src/main/java/io/kroki/server/service/Goat.java
@@ -28,7 +28,10 @@ public class Goat implements DiagramService {
     this.sourceDecoder = new SourceDecoder() {
       @Override
       public String decode(String encoded) throws DecodeException {
-        return DiagramSource.decode(encoded);
+        // GoAT renders ASCII art on a character grid, so leading whitespace is
+        // significant. Decode without trimming to preserve the indentation of
+        // the first line (see Svgbob, Ditaa).
+        return DiagramSource.decode(encoded, false);
       }
     };
     this.commander = commander;

--- a/server/src/test/java/io/kroki/server/service/GoatServiceTest.java
+++ b/server/src/test/java/io/kroki/server/service/GoatServiceTest.java
@@ -1,0 +1,37 @@
+package io.kroki.server.service;
+
+import io.kroki.server.action.Commander;
+import io.kroki.server.decode.DiagramSource;
+import io.kroki.server.error.DecodeException;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+import io.vertx.junit5.VertxExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(VertxExtension.class)
+public class GoatServiceTest {
+
+  private static Goat newGoat(Vertx vertx) {
+    JsonObject config = new JsonObject();
+    return new Goat(vertx, config, new Commander(config));
+  }
+
+  @Test
+  public void should_preserve_leading_whitespace_on_the_first_line(Vertx vertx) throws DecodeException {
+    // GoAT is whitespace-sensitive: the first line is indented by 4 spaces just
+    // like the others. Trimming the source would strip that indentation, shifting
+    // the top border to x=0 and misaligning the box.
+    String source = "    .------------.\n" +
+      "o-->|Hello, world|--*\n" +
+      "    '------------'\n";
+    String encoded = new String(DiagramSource.encode(source));
+
+    String decoded = newGoat(vertx).getSourceDecoder().decode(encoded);
+
+    assertThat(decoded).isEqualTo(source);
+    assertThat(decoded).startsWith("    .");
+  }
+}


### PR DESCRIPTION
GoAT renders ASCII art on a character grid, so leading whitespace is significant. The service decoded the source with DiagramSource.decode(encoded), which trims the whole string and therefore strips the indentation of the first line. This shifted the box top border to x=0 and misaligned the diagram while the other borders stayed correct.

Decode without trimming, like the other whitespace-sensitive engines (Svgbob, Ditaa, Symbolator), and add a service test asserting the first line indentation is preserved.