### PR TITLE
chore(ci): run apt-get update before apt-get install

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -187,7 +187,7 @@ jobs:
         printSavedSpace $((AVAILABLE_END - AVAILABLE_INITIAL))
 
     - name: Install GraphViz
-      run: sudo apt-get install graphviz -y
+      run: sudo apt-get update && sudo apt-get install graphviz -y
 
     - name: Set up JDK 21
       uses: actions/setup-java@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Install GraphViz
-        run: sudo apt-get install graphviz -y
+        run: sudo apt-get update && sudo apt-get install graphviz -y
       - name: Set up JDK 21
         uses: actions/setup-java@v5
         with:
@@ -263,7 +263,7 @@ jobs:
         with:
           ref: ${{ env.RELEASE_VERSION }}
       - name: Install GraphViz
-        run: sudo apt-get install graphviz -y
+        run: sudo apt-get update && sudo apt-get install graphviz -y
       - name: Set up JDK 21
         uses: actions/setup-java@v5
         with:


### PR DESCRIPTION
Ensure that the apt-get cache is up-to-date.