### PR TITLE
fix(security): 2 improvements across 2 files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ versioned entry and uses it as the GitHub release notes.
 
 - Add `background` and `transparent` options to Ditaa diagrams, to set the background colour of the image or make it transparent
 
+### Security
+
+- Prevent BPMN diagram source from executing arbitrary HTML/JavaScript in the companion's headless Chromium page: the diagram source was assigned to the rendering container via `innerHTML` before being handed to bpmn-js, so a crafted request to `/bpmn/svg` could inject an element (e.g. `<img onerror=...>`) that ran script in that page; combined with the browser's `--disable-web-security` flag (same-origin policy disabled), that script could issue cross-origin requests and read the responses. Fixed by clearing the container instead of parsing the diagram source as HTML, and by dropping `--disable-web-security` — the only reason it was set, local file access, is already covered by the shared `--allow-file-access-from-files` flag ([#2089](https://github.com/yuzutech/kroki/pull/2089))
+
 ## [0.31.2] - 2026-07-26
 
 ### Security

--- a/bpmn/README.md
+++ b/bpmn/README.md
@@ -1,0 +1,26 @@
+# BPMN server
+
+Version: 18.18.0 ([bpmn-js](https://github.com/bpmn-io/bpmn-js))
+
+Renders BPMN 2.0 XML into SVG using a headless Chromium instance running the
+[bpmn-js](https://github.com/bpmn-io/bpmn-js) viewer. See `src/worker.js` for
+the conversion flow and `src/browser-instance.js` for the Chromium launch
+flags (shared defaults live in `../lib/browser-instance`).
+
+## Update
+
+`assets/bpmn-viewer.production.min.js` is a pre-built bundle of bpmn-js that
+is committed to the repository and loaded by `assets/index.html` at
+conversion time — the Docker image runs `node src/index.js` directly, so the
+bundle is not regenerated at build time.
+
+To update the bpmn-js version:
+
+1. Bump the `bpmn-js` version in `package.json`.
+2. Run `npm install`.
+3. Run `npm start` (or `npm run prestart`) to copy the freshly installed
+   `node_modules/bpmn-js/dist/bpmn-viewer.production.min.js` over
+   `assets/bpmn-viewer.production.min.js`.
+4. Commit the regenerated `assets/bpmn-viewer.production.min.js` along with
+   the `package.json`/`package-lock.json` changes, and update the version
+   above.

--- a/bpmn/src/browser-instance.js
+++ b/bpmn/src/browser-instance.js
@@ -6,9 +6,5 @@ import { logger } from './logger.js'
 export const { getBrowserWSEndpoint, protocolTimeout } = createBrowserInstance({
   puppeteer,
   logger,
-  envPrefix: 'KROKI_BPMN',
-  extraArgs: [
-    // disable web security to access local files
-    '--disable-web-security'
-  ]
+  envPrefix: 'KROKI_BPMN'
 })

--- a/bpmn/src/worker.js
+++ b/bpmn/src/worker.js
@@ -44,7 +44,7 @@ export class Worker {
           async (bpmnXML, _options) => {
             try {
               const container = document.getElementById('container')
-              container.innerHTML = bpmnXML
+              container.textContent = ''
               /* global BpmnJS */
               const viewer = new BpmnJS({ container })
               await viewer.importXML(bpmnXML)


### PR DESCRIPTION
## Summary

fix(security): 2 improvements across 2 files

## Problem

**Severity**: `High` | **File**: `bpmn/src/browser-instance.js:L12`

The browser-instance.js file launches Puppeteer with the '--disable-web-security' flag, which disables the same-origin policy and other web security features in Chromium. This is a dangerous configuration that allows pages to bypass cross-origin restrictions, potentially enabling malicious content to access local files, make unauthorized cross-origin requests, or exploit other security vulnerabilities. While this may be intentional to allow local file access for diagram rendering, it significantly increases the attack surface.

## Solution

Remove the --disable-web-security flag if possible. If local file access is required, consider using --allow-file-access-from-files instead, or serve files through a local HTTP server. If the flag must be kept, ensure the browser instance is properly isolated and only processes trusted content.

## Changes

- `bpmn/src/browser-instance.js` (modified)
- `bpmn/src/worker.js` (modified)