### PR TITLE
Update README.adoc

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -167,6 +167,8 @@ services:
       - KROKI_MERMAID_HOST=mermaid
       - KROKI_BPMN_HOST=bpmn
       - KROKI_EXCALIDRAW_HOST=excalidraw
+      # experimental!
+      - KROKI_DIAGRAMSNET_HOST=diagramsnet
     ports:
       - "8000:8000"
   mermaid:


### PR DESCRIPTION
Fix confusing 404 "127.0.0.1:8005" error in example Docker Compose