### PR TITLE
ci(release): generate release notes from a changelog

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,20 +1,12 @@
 name: Release
-run-name: >-
-  ${{ github.event_name == 'workflow_dispatch'
-    && format('Release v{0} by {1}',
-              inputs.release_version,
-              github.actor)
-    || format('Release {0}', github.ref_name) }}
+run-name: Release v${{ inputs.release_version }} by ${{ github.actor }}
 
 on:
-  push:
-    tags:
-      - 'v*' # Push events to matching v*, i.e. v1.0, v2.1.3
   workflow_dispatch:
     inputs:
       release_version:
         description: 'Release version'
-        required: false
+        required: true
         type: string
       create_tag:
         description: 'Create a tag'
@@ -35,9 +27,13 @@ on:
 jobs:
   release:
     runs-on: ubuntu-24.04
-    if:  ${{ inputs.release_version != '' }}
     steps:
       - uses: actions/checkout@v6
+        with:
+          # When create_tag is unchecked, the tag must already exist (retry of a
+          # failed release): build from it so the artifacts match the tag even if
+          # the branch has moved since.
+          ref: ${{ inputs.create_tag && github.ref || format('v{0}', inputs.release_version) }}
       - name: Install GraphViz
         run: sudo apt-get update && sudo apt-get install graphviz -y
       - name: Set up JDK 21
@@ -54,6 +50,7 @@ jobs:
         if:  ${{ inputs.create_tag }}
         run: |
           task mavenSetVersion
+          node ci/tasks/changelog.js release "$RELEASE_VERSION"
 
           RELEASE_GIT_NAME=$(curl -s https://api.github.com/users/$GITHUB_ACTOR | jq -r .name)
           RELEASE_GIT_EMAIL=$RELEASE_USER@users.noreply.github.com
@@ -70,10 +67,7 @@ jobs:
           BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       - name: Build Java server
         run: task mavenBuild
-      - if: github.event_name == 'push'
-        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
-      - if: github.event_name == 'workflow_dispatch'
-        run: echo "RELEASE_VERSION=v$RELEASE_VERSION" >> $GITHUB_ENV
+      - run: echo "RELEASE_VERSION=v$RELEASE_VERSION" >> $GITHUB_ENV
         env:
           RELEASE_VERSION: ${{ inputs.release_version }}
       - name: Generate checksums
@@ -85,12 +79,19 @@ jobs:
       - name: Create release
         if:  ${{ inputs.create_gh_release }}
         run: |
-          gh release create "${{ env.RELEASE_VERSION }}"
-          gh release upload "${{ env.RELEASE_VERSION }}" ./server/target/kroki-standalone-server-* --clobber
+          if ! gh release view "$RELEASE_VERSION" > /dev/null 2>&1; then
+            node ci/tasks/changelog.js notes "${RELEASE_VERSION#v}" > release-notes.md
+            gh release create "$RELEASE_VERSION" \
+              --title "$RELEASE_VERSION" \
+              --notes-file release-notes.md \
+              --generate-notes
+          fi
+          gh release upload "$RELEASE_VERSION" ./server/target/kroki-standalone-server-* --clobber
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   publish_dockerhub:
     runs-on: ubuntu-24.04
+    needs: release
     if:  ${{ inputs.publish_dockerhub }}
     steps:
       - name: Free up disk space
@@ -253,10 +254,7 @@ jobs:
           printSavedSpace $((AVAILABLE_ROOT_END - AVAILABLE_ROOT_INITIAL))
           echo "overall:"
           printSavedSpace $((AVAILABLE_END - AVAILABLE_INITIAL))
-      - if: github.event_name == 'push'
-        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
-      - if: github.event_name == 'workflow_dispatch'
-        run: echo "RELEASE_VERSION=v$RELEASE_VERSION" >> $GITHUB_ENV
+      - run: echo "RELEASE_VERSION=v$RELEASE_VERSION" >> $GITHUB_ENV
         env:
           RELEASE_VERSION: ${{ inputs.release_version }}
       - uses: actions/checkout@v6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,46 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+Changes land in the `Unreleased` section as part of the pull request that introduces them.
+On release, the [Release workflow](.github/workflows/release.yml) rolls this section into a
+versioned entry and uses it as the GitHub release notes.
+
+## [Unreleased]
+
+### Fixed
+
+- Preserve leading whitespace of the first line in GoAT diagrams ([#2086](https://github.com/yuzutech/kroki/pull/2086))
+
+### Diagram libraries
+
+- Update blockdiag to 3.4.2 ([#2085](https://github.com/yuzutech/kroki/pull/2085))
+
+## [0.31.0] - 2026-06-11
+
+This release adds support for GoAT diagrams and brings back the ELK and tidy-tree layouts in Mermaid 🎉
+
+### Added
+
+- Integrate GoAT (Go ASCII diagrams) ([#2033](https://github.com/yuzutech/kroki/pull/2033))
+- Support ELK and tidy-tree alternate layouts in Mermaid ([#2080](https://github.com/yuzutech/kroki/pull/2080))
+
+### Fixed
+
+- Prevent browser leak and bound resource usage in companion containers ([#2076](https://github.com/yuzutech/kroki/pull/2076))
+
+### Diagram libraries
+
+- blockdiag (actdiag, nwdiag, packetdiag, rackdiag, seqdiag) 3.3.0
+- BPMN 18.18.0
+- diagrams.net 29.6.1
+- Excalidraw 0.18.1
+- GraphViz 14.1.3
+- Mermaid 11.15.0
+- PlantUML (and C4) 1.2026.6
+- Structurizr 6.2.1
+- Vega-Lite 6.4.3
+- WaveDrom 3.6.1

--- a/ci/tasks/changelog.js
+++ b/ci/tasks/changelog.js
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+// Changelog automation for the release workflow.
+//
+// Usage:
+//   node ci/tasks/changelog.js release <version>   Roll "## [Unreleased]" into a dated
+//                                                  "## [<version>]" section and start a
+//                                                  fresh, empty "## [Unreleased]" section.
+//   node ci/tasks/changelog.js notes <version>     Print the body of the "## [<version>]"
+//                                                  section to stdout (used as release notes).
+//
+// The changelog follows the "Keep a Changelog" format.
+
+import { readFileSync, writeFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const CHANGELOG_PATH = join(
+  dirname(fileURLToPath(import.meta.url)),
+  '..',
+  '..',
+  'CHANGELOG.md',
+)
+const UNRELEASED_HEADING = '## [Unreleased]'
+
+function fail(message) {
+  console.error(`changelog: ${message}`)
+  process.exit(1)
+}
+
+function today() {
+  return new Date().toISOString().slice(0, 10)
+}
+
+function release(version) {
+  const content = readFileSync(CHANGELOG_PATH, 'utf8')
+  if (!content.includes(UNRELEASED_HEADING)) {
+    fail(`no "${UNRELEASED_HEADING}" section found in CHANGELOG.md`)
+  }
+  if (content.includes(`## [${version}]`)) {
+    fail(`a section for version ${version} already exists in CHANGELOG.md`)
+  }
+  // Keep an empty Unreleased section on top and move its current content under the new version.
+  const updated = content.replace(
+    UNRELEASED_HEADING,
+    `${UNRELEASED_HEADING}\n\n## [${version}] - ${today()}`,
+  )
+  writeFileSync(CHANGELOG_PATH, updated)
+  console.error(`changelog: released ${version}`)
+}
+
+function notes(version) {
+  const lines = readFileSync(CHANGELOG_PATH, 'utf8').split('\n')
+  const start = lines.findIndex((line) => line.startsWith(`## [${version}]`))
+  if (start === -1) {
+    fail(`no section for version ${version} found in CHANGELOG.md`)
+  }
+  let end = lines.findIndex(
+    (line, index) => index > start && line.startsWith('## '),
+  )
+  if (end === -1) {
+    end = lines.length
+  }
+  process.stdout.write(
+    `${lines
+      .slice(start + 1, end)
+      .join('\n')
+      .trim()}\n`,
+  )
+}
+
+const [command, version] = process.argv.slice(2)
+if (!version) {
+  fail(`usage: node ci/tasks/changelog.js <release|notes> <version>`)
+}
+if (command === 'release') {
+  release(version)
+} else if (command === 'notes') {
+  notes(version)
+} else {
+  fail(`unknown command "${command}" (expected "release" or "notes")`)
+}


### PR DESCRIPTION
Introduce CHANGELOG.md (Keep a Changelog format) and ci/tasks/changelog.js to roll the Unreleased section on release and generate the GitHub release notes from it.

Rework the release workflow around workflow_dispatch only:
- remove the dead push-tags trigger (jobs were gated on empty inputs)
- build from the existing tag when create_tag is unchecked, so a failed release can be retried with artifacts matching the tag
- skip GitHub release creation when it already exists (retry only re-uploads artifacts)
- run publish_dockerhub after the release job so the tag it checks out is guaranteed to exist

Resolves https://github.com/yuzutech/kroki/issues/121