### PR TITLE
fix(mermaid): cap concurrent conversions to bound Chromium memory usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ versioned entry and uses it as the GitHub release notes.
 
 - Update Node.js base Docker images to 24.18 (Bookworm) ([#2097](https://github.com/yuzutech/kroki/pull/2097))
 
+### Fixed
+
+- Cap concurrent Mermaid conversions (`KROKI_MERMAID_MAX_CONCURRENCY`, default 6) to bound Chromium memory usage; a burst of simultaneous requests could otherwise spin up enough renderer processes to exceed the container's memory limit and crash the service
+
 ### Diagram libraries
 
 - Update Structurizr to 6.2.2 ([#2099](https://github.com/yuzutech/kroki/pull/2099))

--- a/docs/modules/setup/pages/configuration.adoc
+++ b/docs/modules/setup/pages/configuration.adoc
@@ -271,6 +271,18 @@ In addition, Mermaid's own edge limit (`maxEdges`, 500 by default) is enforced: 
 
 NOTE: For security reasons, `maxTextSize`, `maxEdges`, `securityLevel`, `secure` and `startOnLoad` cannot be overridden per request through query parameters.
 
+=== Mermaid Concurrency Limit
+
+The Mermaid container opens one Chromium page per render. Without a limit, a burst of simultaneous conversions could spin up enough renderer processes to exceed the container's memory limit and crash the browser.
+Requests beyond the limit queue instead of spawning unbounded pages.
+
+You can adjust this with the `KROKI_MERMAID_MAX_CONCURRENCY` environment variable:
+
+[source]
+----
+KROKI_MERMAID_MAX_CONCURRENCY=6 # default
+----
+
 == Companion Container Host and Port
 
 You can configure the host and port on which every companion container will be listening:

--- a/mermaid/src/index.js
+++ b/mermaid/src/index.js
@@ -33,7 +33,10 @@ import Task from './task.js'
             const isPng = outputType === 'png'
             // Fail closed: an unrecognized or missing value is treated as 'secure'.
             const safeMode = url.searchParams.get('safeMode') === 'unsafe' ? 'unsafe' : 'secure'
-            const output = await worker.convert(new Task(diagramSource, isPng, safeMode), url.searchParams)
+            const output = await worker.convert(
+              new Task(diagramSource, isPng, safeMode),
+              url.searchParams
+            )
             res.setHeader('Content-Type', isPng ? 'image/png' : 'image/svg+xml')
             return micro.send(res, 200, output)
           } catch (err) {

--- a/mermaid/src/worker.js
+++ b/mermaid/src/worker.js
@@ -30,12 +30,46 @@ export class MaxTextSizeError extends Error {
   }
 }
 
+// Caps how many pages (and therefore Chromium renderer processes) may be open
+// at once. A single shared Chrome instance (see browser-instance.js) has no
+// built-in limit on concurrent pages: a burst of requests can spin up enough
+// renderer processes to exceed the container's memory/pids limits and crash
+// the browser launch itself (posix_spawn: Resource temporarily unavailable).
+// Requests beyond the cap simply wait their turn instead.
+class Semaphore {
+  constructor(max) {
+    this.max = max
+    this.count = 0
+    this.queue = []
+  }
+
+  async acquire() {
+    if (this.count < this.max) {
+      this.count++
+      return
+    }
+    return new Promise(resolve => this.queue.push(resolve))
+  }
+
+  release() {
+    const next = this.queue.shift()
+    if (next) {
+      next()
+    } else {
+      this.count--
+    }
+  }
+}
+
+const MAX_CONCURRENCY = Number(process.env.KROKI_MERMAID_MAX_CONCURRENCY) || 6
+
 export class Worker {
   constructor() {
     this.pageUrl =
       process.env.KROKI_MERMAID_PAGE_URL ||
       `file://${path.join(__dirname, '..', 'assets', 'index.html')}`
     this.convertTimeout = process.env.KROKI_MERMAID_CONVERT_TIMEOUT || '10000'
+    this.semaphore = new Semaphore(MAX_CONCURRENCY)
   }
 
   async convert(task, config) {
@@ -47,6 +81,7 @@ export class Worker {
     if (maxTextSize && task.source.length > maxTextSize) {
       throw new MaxTextSizeError(task.source.length, maxTextSize)
     }
+    await this.semaphore.acquire()
     const browser = await this._connect()
     const page = await newPage(browser)
     try {
@@ -82,6 +117,7 @@ export class Worker {
       } catch (err) {
         logger.warn({ err }, 'Unable to disconnect from the browser')
       }
+      this.semaphore.release()
     }
   }
 


### PR DESCRIPTION
The mermaid service opened a new Chromium page per request with no limit on concurrency. A burst of simultaneous conversions could spin up enough renderer processes to exceed the container's memory limit, causing the browser's own process launches to fail with EAGAIN (posix_spawn: Resource temporarily unavailable) and taking the service down.

Requests beyond KROKI_MERMAID_MAX_CONCURRENCY (default 6) now queue instead of spawning unbounded pages.