### PR TITLE
feat(ditaa): add background and transparent options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ versioned entry and uses it as the GitHub release notes.
 
 ## [Unreleased]
 
+### Added
+
+- Add `background` and `transparent` options to Ditaa diagrams, to set the background colour of the image or make it transparent
+
 ## [0.31.2] - 2026-07-26
 
 ### Security

--- a/docs/modules/setup/pages/diagram-options.adoc
+++ b/docs/modules/setup/pages/diagram-options.adoc
@@ -108,6 +108,15 @@ empty string ("")
 |tabs
 |_any_ +
 |Tabs are normally interpreted as 8 spaces but it is possible to change that using this option
+
+|background
+|_six-digit hexadecimal number_ +
+*`FFFFFF`*
+|The background colour of the image. The format should be a six-digit hexadecimal number (as in HTML, FF0000 for red). This is overridden by `transparent`
+
+|transparent
+|_any_ +
+|Makes the background of the image transparent. This overrides `background`
 |===
 
 == GoAT

--- a/server/src/main/java/io/kroki/server/service/DitaaCommand.java
+++ b/server/src/main/java/io/kroki/server/service/DitaaCommand.java
@@ -55,6 +55,15 @@ public class DitaaCommand {
       commands.add("--tabs");
       commands.add(tabs);
     }
+    String background = options.getString("background");
+    if (background != null) {
+      commands.add("--background");
+      commands.add(background);
+    }
+    String transparent = options.getString("transparent");
+    if (transparent != null) {
+      commands.add("--transparent");
+    }
     commands.add("-");
     logger.info("commands: {}", Arrays.toString(commands.toArray(new String[0])));
     return commander.execute(source.getBytes(), commands.toArray(new String[0]));

--- a/server/src/test/java/io/kroki/server/service/DitaaServiceTest.java
+++ b/server/src/test/java/io/kroki/server/service/DitaaServiceTest.java
@@ -62,6 +62,47 @@ public class DitaaServiceTest {
   }
 
   @Test
+  public void should_call_ditaa_with_background() throws Exception {
+    String input = "+---------+\n" +
+      "| cBLU    |\n" +
+      "|         |\n" +
+      "|    +----+\n" +
+      "|    |cPNK|\n" +
+      "|    |    |\n" +
+      "+----+----+";
+
+    // background is white by default
+    byte[] defaultResult = ditaaCommand.convert(input, FileFormat.SVG, new JsonObject());
+    assertThat(new String(defaultResult, StandardCharsets.UTF_8)).contains("style=\"fill: #ffffff\"");
+
+    JsonObject options = new JsonObject();
+    options.put("background", "FF0000");
+    byte[] result = ditaaCommand.convert(input, FileFormat.SVG, options);
+    assertThat(new String(result, StandardCharsets.UTF_8)).contains("style=\"fill: #ff0000\"");
+  }
+
+  @Test
+  public void should_call_ditaa_with_transparent() throws Exception {
+    String input = "+---------+\n" +
+      "| cBLU    |\n" +
+      "|         |\n" +
+      "|    +----+\n" +
+      "|    |cPNK|\n" +
+      "|    |    |\n" +
+      "+----+----+";
+
+    // background is not transparent by default
+    byte[] withoutTransparent = ditaaCommand.convert(input, FileFormat.SVG, new JsonObject());
+    assertThat(new String(withoutTransparent, StandardCharsets.UTF_8)).contains("style=\"fill: #ffffff\"");
+
+    // enable transparency by setting the transparent option
+    JsonObject options = new JsonObject();
+    options.put("transparent", "");
+    byte[] withTransparent = ditaaCommand.convert(input, FileFormat.SVG, options);
+    assertThat(new String(withTransparent, StandardCharsets.UTF_8)).doesNotContain("style=\"fill: #ffffff\"");
+  }
+
+  @Test
   public void should_call_ditaa_with_scale() throws Exception {
     String input = "+---------+\n" +
       "| cBLU    |\n" +


### PR DESCRIPTION
Ditaa's CLI already supports --background and --transparent, this wires them through so diagrams can set a custom background colour or render with a transparent one instead of the default white.