### PR TITLE
fix: upgrade immutable to 4.3.9, 5.1.8 (CVE-2026-59879)

### DIFF
--- a/excalidraw/package-lock.json
+++ b/excalidraw/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@excalidraw/excalidraw": "0.18.1",
         "@kroki/browser-instance": "file:../lib/browser-instance",
+        "immutable": "^4.3.9",
         "micro": "10.0.1",
         "pino": "9.14.0",
         "pino-debug": "2.0.0",
@@ -122,9 +123,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -142,9 +140,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -162,9 +157,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -182,9 +174,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -3017,9 +3006,9 @@
       }
     },
     "node_modules/immutable": {
-      "version": "4.3.8",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.8.tgz",
-      "integrity": "sha512-d/Ld9aLbKpNwyl0KiM2CT1WYvkitQ1TSvmRtkcV8FKStiDoA7Slzgjmb/1G2yhKM1p0XeNOieaTbFZmU1d3Xuw==",
+      "version": "4.3.9",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.9.tgz",
+      "integrity": "sha512-ObHy4YN7ycwZOUCLI1/6svfyAFu7vL8RhAvVu/bh/RZW9EPlOyDaQ9jDQWCtdqzaXUjgXZCW1migtHE7YI7UGQ==",
       "license": "MIT"
     },
     "node_modules/import-meta-resolve": {

--- a/excalidraw/package.json
+++ b/excalidraw/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "@excalidraw/excalidraw": "0.18.1",
     "@kroki/browser-instance": "file:../lib/browser-instance",
+    "immutable": "^4.3.9",
     "micro": "10.0.1",
     "pino": "9.14.0",
     "pino-debug": "2.0.0",


### PR DESCRIPTION
## Summary
Upgrade immutable from 4.3.8 to 4.3.9, 5.1.8 to fix CVE-2026-59879.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | CVE-2026-59879 |
| **Severity** | HIGH |
| **Scanner** | trivy |
| **Rule** | `CVE-2026-59879` |
| **File** | `excalidraw/package-lock.json` |
| **Assessment** | Likely exploitable |

**Description**: Immutable.js provides many Persistent Immutable data structures. Prior ...

## Evidence

**Scanner confirmation**: trivy rule `CVE-2026-59879` flagged this pattern.

**Production code**: This file is in the production codebase, not test-only code.

## Threat Model Context

This is a Node.js library - vulnerabilities affect downstream consumers who use this package.

## Changes
- `excalidraw/package.json`
- `excalidraw/package-lock.json`

## Behavior Preservation
The change is scoped to 2 files on the vulnerable path, and the project's existing tests still pass, so intended behavior is unchanged.

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*This change addresses a pattern flagged by static analysis. The code path handles user-influenced input and the fix reduces the attack surface against both manual and automated exploitation.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
