### PR TITLE
fix(companions): prevent Chromium crashes and connection pool exhaustion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ versioned entry and uses it as the GitHub release notes.
 
 - Prevent BPMN diagram source from executing arbitrary HTML/JavaScript in the companion's headless Chromium page: the diagram source was assigned to the rendering container via `innerHTML` before being handed to bpmn-js, so a crafted request to `/bpmn/svg` could inject an element (e.g. `<img onerror=...>`) that ran script in that page; combined with the browser's `--disable-web-security` flag (same-origin policy disabled), that script could issue cross-origin requests and read the responses. Fixed by clearing the container instead of parsing the diagram source as HTML, and by dropping `--disable-web-security` — the only reason it was set, local file access, is already covered by the shared `--allow-file-access-from-files` flag ([#2089](https://github.com/yuzutech/kroki/pull/2089))
 
+### Fixed
+
+- Prevent the headless Chromium instance shared by the Mermaid, BPMN, Excalidraw and diagrams.net companions from crashing once it exhausts Docker's default 64MB `/dev/shm`, by passing `--disable-dev-shm-usage` so Chromium falls back to `/tmp`
+
 ## [0.31.2] - 2026-07-26
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ versioned entry and uses it as the GitHub release notes.
 ### Fixed
 
 - Prevent the headless Chromium instance shared by the Mermaid, BPMN, Excalidraw and diagrams.net companions from crashing once it exhausts Docker's default 64MB `/dev/shm`, by passing `--disable-dev-shm-usage` so Chromium falls back to `/tmp`
+- Raise the core's HTTP connection pool towards each companion from Vert.x's default of 5 to 10 (configurable via `KROKI_DELEGATE_MAX_POOL_SIZE`), so a degraded companion (e.g. Mermaid restarting Chromium after a crash) doesn't starve unrelated requests of a pooled connection and fail them with a `getting a connection` timeout before the companion itself is actually overloaded
 
 ## [0.31.2] - 2026-07-26
 

--- a/docs/modules/setup/pages/configuration.adoc
+++ b/docs/modules/setup/pages/configuration.adoc
@@ -234,6 +234,23 @@ KROKI_DELEGATE_TIMEOUT_MS=30000 # default, 30 seconds
 NOTE: The companions enforce their own convert timeout (10 seconds by default for Mermaid, see xref:mermaid-convert-timeout[] below).
 Keep `KROKI_DELEGATE_TIMEOUT_MS` slightly higher so the companion's structured error response is returned to the client instead of being cut short.
 
+== Delegate Connection Pool Size
+
+The main server keeps a pool of HTTP connections open to each companion container, reused across requests.
+By default, up to 5 connections are kept per companion.
+
+If a companion is degraded (for instance, Mermaid's Chromium instance restarting after a crash), in-flight requests can hold their connection for as long as `KROKI_DELEGATE_TIMEOUT_MS`.
+Once every pooled connection is in that state, further requests cannot even acquire one and fail with a `"...exceeded when getting a connection"` timeout, even though the companion itself is not actually overloaded.
+
+You can raise the pool size with the `KROKI_DELEGATE_MAX_POOL_SIZE` environment variable:
+
+[source]
+----
+KROKI_DELEGATE_MAX_POOL_SIZE=10 # default
+----
+
+TIP: For Mermaid, keep this at or above `KROKI_MERMAID_MAX_CONCURRENCY` (see xref:mermaid-concurrency-limit[] below) so the pool is never the bottleneck below what the companion can actually process concurrently.
+
 == Companion Browser
 
 Mermaid, Excalidraw and diagrams.net render diagrams in a headless Chromium instance driven over the Chrome DevTools Protocol (CDP).
@@ -271,6 +288,7 @@ In addition, Mermaid's own edge limit (`maxEdges`, 500 by default) is enforced: 
 
 NOTE: For security reasons, `maxTextSize`, `maxEdges`, `securityLevel`, `secure` and `startOnLoad` cannot be overridden per request through query parameters.
 
+[#mermaid-concurrency-limit]
 === Mermaid Concurrency Limit
 
 The Mermaid container opens one Chromium page per render. Without a limit, a burst of simultaneous conversions could spin up enough renderer processes to exceed the container's memory limit and crash the browser.

--- a/lib/browser-instance/index.js
+++ b/lib/browser-instance/index.js
@@ -16,6 +16,10 @@ const BASE_ARGS = [
   '--disable-gpu',
   '--disable-software-rasterizer',
   '--disable-translate',
+  // Docker's default /dev/shm is 64MB, far below what Chromium wants for shared
+  // memory. Without this flag, Chromium crashes (often SIGABRT/SIGSEGV) once it
+  // exhausts /dev/shm instead of falling back to /tmp.
+  '--disable-dev-shm-usage',
   // Disable the setuid sandbox (Linux only)
   '--disable-setuid-sandbox',
   // Run in headless mode, i.e., without a UI or display server dependencies

--- a/server/src/main/java/io/kroki/server/action/Delegator.java
+++ b/server/src/main/java/io/kroki/server/action/Delegator.java
@@ -9,6 +9,7 @@ import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.HttpHeaders;
+import io.vertx.core.http.PoolOptions;
 import io.vertx.core.json.DecodeException;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.client.HttpRequest;
@@ -30,6 +31,13 @@ public class Delegator {
   // a timeout a wedged companion lets requests pile up in the client queue until
   // the core runs out of memory.
   private static final long DEFAULT_TIMEOUT_MS = 30_000;
+  // Vert.x's own default (5) is below Mermaid's KROKI_MERMAID_MAX_CONCURRENCY (6,
+  // see mermaid/src/worker.js): when the companion is degraded (e.g. Chromium
+  // restarting after a crash), every in-flight request holds its pooled connection
+  // for up to timeoutMs, so a 6th legitimate request can't even acquire a
+  // connection and times out ("...exceeded when getting a connection to
+  // <host>:<port>") well before the companion itself is actually overloaded.
+  private static final int DEFAULT_MAX_POOL_SIZE = 10;
   private final WebClient webClient;
   private final long timeoutMs;
 
@@ -38,6 +46,8 @@ public class Delegator {
   }
 
   public Delegator(Vertx vertx, JsonObject config) {
+    Integer configuredPoolSize = config.getInteger("KROKI_DELEGATE_MAX_POOL_SIZE");
+    int maxPoolSize = configuredPoolSize != null && configuredPoolSize > 0 ? configuredPoolSize : DEFAULT_MAX_POOL_SIZE;
     HttpClient httpClient = vertx.httpClientBuilder()
       // https://vertx.io/docs/vertx-web-client/java/#_handling_30x_redirections
       // > By default the client follows redirections
@@ -45,6 +55,7 @@ public class Delegator {
       // > For security reason, client won’t follow redirects for request with methods different from GET or HEAD
       // So we need custom redirect handler.
       .withRedirectHandler(new AllowAnyMethodRedirectHandler())
+      .with(new PoolOptions().setHttp1MaxSize(maxPoolSize))
       .build();
     this.webClient = WebClient.wrap(httpClient);
     Long configured = config.getLong("KROKI_DELEGATE_TIMEOUT_MS");


### PR DESCRIPTION
#### Summary

- Pass `--disable-dev-shm-usage` to the headless Chromium instance shared by the Mermaid, BPMN, Excalidraw and diagrams.net companions. Docker's default `/dev/shm` is 64MB, well below what Chromium expects for shared memory; once exhausted it aborted (`SIGABRT`/`SIGSEGV`) instead of degrading gracefully. This flag makes it fall back to `/tmp`.
- Raise the core's HTTP client pool towards each companion from Vert.x's default of 5 to 10, configurable via `KROKI_DELEGATE_MAX_POOL_SIZE`. The old default was below Mermaid's own `KROKI_MERMAID_MAX_CONCURRENCY` (6): when Mermaid was briefly degraded (e.g. Chromium restarting after a crash), in-flight requests held their pooled connections for up to 30s, so unrelated legitimate requests couldn't even acquire a connection and failed with `"...exceeded when getting a connection to mermaid:8002"` well before Mermaid itself was actually overloaded.

Diagnosed on a live deployment by sampling `/metrics` (`kroki_worker_thread_blocked_percentage` / `kroki_event_loop_thread_blocked_percentage`, both 0% throughout) and forcing periodic JVM thread dumps (SIGQUIT) during CPU spikes — ruling out stuck Vert.x threads and pointing instead at connection-pool exhaustion correlated with Mermaid's Chromium crashes.