### PR TITLE
chore(deps): update Node.js base Docker images to alpine3.24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ versioned entry and uses it as the GitHub release notes.
 - Prevent unauthenticated remote code execution on `/tikz/svg` via `\special{ps:...}`: `dvisvgm` hands PostScript specials embedded in the DVI off to Ghostscript, which `dvisvgm` starts with `-dDELAYSAFER` instead of `-dSAFER`, leaving the `%pipe%` device available and allowing arbitrary command execution regardless of `KROKI_SAFE_MODE` — including `SECURE`, since that setting only restricts kpathsea (LaTeX) file access and has no effect on Ghostscript. Fixed by passing `--no-specials=ps` to `dvisvgm` so PostScript specials are never processed
 - Prevent BPMN diagram source from executing arbitrary HTML/JavaScript in the companion's headless Chromium page: the diagram source was assigned to the rendering container via `innerHTML` before being handed to bpmn-js, so a crafted request to `/bpmn/svg` could inject an element (e.g. `<img onerror=...>`) that ran script in that page; combined with the browser's `--disable-web-security` flag (same-origin policy disabled), that script could issue cross-origin requests and read the responses. Fixed by clearing the container instead of parsing the diagram source as HTML, and by dropping `--disable-web-security` — the only reason it was set, local file access, is already covered by the shared `--allow-file-access-from-files` flag ([#2089](https://github.com/yuzutech/kroki/pull/2089))
 
+### Changed
+
+- Update Node.js base Docker images to 24.18 (Alpine 3.24) for the Mermaid, BPMN, Excalidraw and diagrams.net companions
+
 ### Fixed
 
 - Prevent the headless Chromium instance shared by the Mermaid, BPMN, Excalidraw and diagrams.net companions from crashing once it exhausts Docker's default 64MB `/dev/shm`, by passing `--disable-dev-shm-usage` so Chromium falls back to `/tmp`

--- a/bpmn/Dockerfile
+++ b/bpmn/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:24.18-alpine3.23
+FROM node:24.18-alpine3.24
 
 RUN addgroup -g 1001 kroki && adduser -D -G kroki -u 1001 kroki
 

--- a/diagrams.net/Dockerfile
+++ b/diagrams.net/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:24.18-alpine3.23
+FROM node:24.18-alpine3.24
 
 RUN addgroup -g 1001 kroki && adduser -D -G kroki -u 1001 kroki
 

--- a/excalidraw/Dockerfile
+++ b/excalidraw/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:24.18-alpine3.23 AS builder
+FROM node:24.18-alpine3.24 AS builder
 
 WORKDIR /usr/local/kroki/
 
@@ -12,7 +12,7 @@ COPY package*.json ./
 RUN npm i
 RUN npm run build
 
-FROM node:24.18-alpine3.23
+FROM node:24.18-alpine3.24
 
 RUN addgroup -g 1001 kroki && adduser -D -G kroki -u 1001 kroki
 

--- a/mermaid/Dockerfile
+++ b/mermaid/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:24.18-alpine3.23
+FROM node:24.18-alpine3.24
 
 RUN addgroup -g 1001 kroki && adduser -D -G kroki -u 1001 kroki
 


### PR DESCRIPTION
Bump the Mermaid, BPMN, Excalidraw and diagrams.net companion base images from alpine3.23 to alpine3.24.

Resolves #2112 