### PR TITLE
feat: add companion service discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ versioned entry and uses it as the GitHub release notes.
 ### Added
 
 - Add `background` and `transparent` options to Ditaa diagrams, to set the background colour of the image or make it transparent
+- Add companion service discovery: a companion container not built into Kroki can now register itself as a new diagram type via `POST /services` (with a heartbeat to stay registered, since the registry is in-memory and does not survive a restart). Disabled by default, opt in with `KROKI_ENABLE_COMPANION_DISCOVERY`; secure the registration API with `KROKI_COMPANION_REGISTRATION_TOKEN`. Always disabled while `KROKI_SAFE_MODE` is `SECURE` (the default, including on kroki.io) ([#1423](https://github.com/yuzutech/kroki/issues/1423))
 
 ### Security
 

--- a/docs/modules/setup/pages/configuration.adoc
+++ b/docs/modules/setup/pages/configuration.adoc
@@ -314,6 +314,88 @@ KROKI_EXCALIDRAW_PORT:: Port of the Excalidraw container (default: `8004`).
 
 NOTE: If you are using the default `docker-compose.yaml` file you can rely on the default values.
 
+== Companion Service Discovery
+
+In addition to the companion containers built into Kroki (Mermaid, BPMN, Excalidraw, diagrams.net), you can extend Kroki with your own companion container for a diagram type that isn't built in. A companion registers itself with the gateway over a small REST API, and Kroki then delegates conversion requests for that diagram type to it — see https://github.com/yuzutech/kroki/issues/1423[issue #1423] for the design discussion.
+
+This feature is disabled by default. Enable it with `KROKI_ENABLE_COMPANION_DISCOVERY=true`.
+
+[IMPORTANT]
+====
+Companion service discovery is always disabled while Kroki runs in `SECURE` safe mode (the default, see <<Safe Mode>>), regardless of `KROKI_ENABLE_COMPANION_DISCOVERY`. `SECURE` means the operator does not trust a service's own security checks, which is exactly what registering a new, unvetted companion would ask the gateway to do. This also means the feature is never available on the public https://kroki.io instance.
+
+To use this feature, explicitly set `KROKI_SAFE_MODE` to `SAFE` or `UNSAFE`.
+====
+
+=== Registering a companion
+
+A companion registers itself by sending its name, version, supported output formats, and where it can be reached:
+
+[source,bash]
+----
+curl -X POST https://my.kroki.example/services \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "name": "mscgen",
+    "version": "1.2.3",
+    "formats": ["png", "svg"],
+    "host": "mscgen-companion",
+    "port": 8080
+  }'
+----
+
+`name`:: The diagram type name, used in the conversion URL (`/mscgen/svg/...`). Must be lowercase letters and digits only, and not already used by a built-in diagram type or another registered companion (`422` otherwise).
+`version`:: A free-form version string, reported on the `/health` endpoint and the homepage.
+`formats`:: A non-empty array of the output formats the companion supports (`png`, `svg`, `jpeg`, `pdf`, `base64`, `txt` or `utxt`).
+`host` and `port`:: Where Kroki should reach the companion. Loopback, link-local (which covers every major cloud provider's instance-metadata address) and private addresses are rejected, as well as a small built-in denylist of cloud metadata hostnames — see `KROKI_COMPANION_BLOCKED_HOSTS` below.
+
+On success, the server responds `201 Created` and the diagram type is immediately available, e.g. `POST /mscgen/svg`. The companion is expected to implement the same wire protocol as Kroki's own companion containers: `POST /<name>/<format>` with the decoded diagram source as the request body.
+
+Since Kroki is stateless, the registry does not survive a restart, and a companion is expected to keep renewing its registration with a heartbeat:
+
+[source,bash]
+----
+curl -X PUT https://my.kroki.example/services/mscgen/heartbeat
+----
+
+A companion that misses its heartbeat deadline (`KROKI_COMPANION_HEARTBEAT_TTL_MS`, default `90000` — 90 seconds) is automatically evicted, freeing up its name. A companion can also unregister explicitly on graceful shutdown:
+
+[source,bash]
+----
+curl -X DELETE https://my.kroki.example/services/mscgen
+----
+
+`GET /services/:name` and `GET /services` return the current registration(s) as JSON, for inspection.
+
+=== Securing the registration API
+
+Since registering a companion lets it serve conversion requests under a new diagram type name, the `/services` API should only be reachable from a trusted network (e.g. a private Docker or Kubernetes network with no route from the outside).
+
+As an additional layer, you can require a bearer token on every `/services` request with `KROKI_COMPANION_REGISTRATION_TOKEN`:
+
+[source,bash]
+----
+KROKI_COMPANION_REGISTRATION_TOKEN=s3cr3t
+----
+
+[source,bash]
+----
+curl -X POST https://my.kroki.example/services \
+  -H 'Authorization: Bearer s3cr3t' \
+  -H 'Content-Type: application/json' \
+  -d '{ "name": "mscgen", "version": "1.2.3", "formats": ["svg"], "host": "mscgen-companion", "port": 8080 }'
+----
+
+If `KROKI_ENABLE_COMPANION_DISCOVERY` is set without a token, Kroki logs a warning on startup: the registration API is then reachable by anyone who can reach the gateway.
+
+=== Companion Service Discovery Environment Variables
+
+`KROKI_ENABLE_COMPANION_DISCOVERY`:: Enables the `/services` registration API. Defaults to `false`. Has no effect while `KROKI_SAFE_MODE` is `SECURE`.
+`KROKI_COMPANION_REGISTRATION_TOKEN`:: Bearer token required on every `/services` request. Optional, but strongly recommended.
+`KROKI_COMPANION_HEARTBEAT_TTL_MS`:: How long a companion may go without a heartbeat before being evicted. Defaults to `90000` (90 seconds).
+`KROKI_COMPANION_HEARTBEAT_SWEEP_INTERVAL_MS`:: How often expired registrations are checked for. Defaults to a third of `KROKI_COMPANION_HEARTBEAT_TTL_MS`, with a floor of `5000`.
+`KROKI_COMPANION_BLOCKED_HOSTS`:: Comma-separated list of additional hostnames to reject as a companion's `host`, on top of the built-in denylist (loopback, link-local, private addresses, and known cloud metadata hostnames).
+
 == Max URI length
 
 Some diagrams, like Excalidraw, have verbose textual descriptions that will produce long URI.

--- a/server/src/main/java/io/kroki/server/Server.java
+++ b/server/src/main/java/io/kroki/server/Server.java
@@ -5,6 +5,10 @@ import io.kroki.server.action.Delegator;
 import io.kroki.server.error.ErrorHandler;
 import io.kroki.server.error.InvalidRequestHandler;
 import io.kroki.server.log.Logging;
+import io.kroki.server.registry.CompanionAuthHandler;
+import io.kroki.server.registry.CompanionRegistry;
+import io.kroki.server.registry.CompanionServiceHandler;
+import io.kroki.server.security.SafeMode;
 import io.kroki.server.service.*;
 import io.vertx.config.ConfigRetriever;
 import io.vertx.core.*;
@@ -20,6 +24,7 @@ import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.handler.BodyHandler;
 import io.vertx.ext.web.handler.CorsHandler;
 
+import java.time.Duration;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -119,6 +124,8 @@ public class Server extends AbstractVerticle {
     registry.register(new Wireviz(vertx, config, commander), "wireviz");
     registry.register(new Goat(vertx, config, commander), "goat");
 
+    mountCompanionDiscovery(vertx, config, router, bodyHandler, delegator, registry);
+
     router.post("/")
       .handler(bodyHandler)
       .handler(new DiagramRest(registry).create());
@@ -130,7 +137,9 @@ public class Server extends AbstractVerticle {
     router.get("/metrics")
       .handler(metricHandlerService);
     // health
-    HealthHandler healthHandler = new HealthHandler(registry.getVersions(), blockedThreadChecker);
+    // queries registry.getVersions() live (rather than a startup snapshot) so that companion
+    // services registered or evicted at runtime (see issue #1423) are reflected immediately
+    HealthHandler healthHandler = new HealthHandler(registry::getVersions, blockedThreadChecker);
     Handler<RoutingContext> healthHandlerService = healthHandler.create();
     router.get("/health")
       .handler(healthHandlerService);
@@ -140,14 +149,16 @@ public class Server extends AbstractVerticle {
       .handler(healthHandlerService);
 
     // hello
-    List<ServiceVersion> serviceVersions = healthHandler.getServiceVersions();
     String krokiBuildHash = healthHandler.getKrokiBuildHash();
     String krokiVersionNumber = healthHandler.getKrokiVersionNumber();
     router.get("/")
-      .handler(new HelloHandler(vertx, serviceVersions, krokiVersionNumber, krokiBuildHash).create());
+      .handler(new HelloHandler(vertx, healthHandler::getServiceVersions, krokiVersionNumber, krokiBuildHash).create());
 
     // Default route
-    Route route = router.route("/*");
+    // Ordered last so that companion services registered dynamically at runtime (see issue
+    // #1423), whose routes are necessarily added to the router after this one, still get a
+    // chance to match instead of always falling through to this catch-all 404.
+    Route route = router.route("/*").order(Integer.MAX_VALUE);
     route.handler(routingContext -> routingContext.fail(404));
     ErrorHandler errorHandler = new ErrorHandler(vertx, config.getBoolean("KROKI_DISPLAY_EXCEPTION_DETAILS", false));
     route.failureHandler(errorHandler);
@@ -156,6 +167,71 @@ public class Server extends AbstractVerticle {
       .invalidRequestHandler(new InvalidRequestHandler(errorHandler, serverOptions.getMaxInitialLineLength()))
       .requestHandler(router)
       .listen(getListenAddress(config));
+  }
+
+  /**
+   * Mounts the companion service discovery REST API (see issue #1423) under {@code /services},
+   * allowing companion containers not built into Kroki to register themselves as a new diagram
+   * type. Disabled by default: this opens a new registration surface that should only be exposed
+   * on a trusted network, ideally with {@code KROKI_COMPANION_REGISTRATION_TOKEN} configured.
+   *
+   * <p>Always disabled under {@code KROKI_SAFE_MODE=SECURE} (the default, including on kroki.io),
+   * regardless of {@code KROKI_ENABLE_COMPANION_DISCOVERY}: SECURE means the operator does not
+   * trust arbitrary services' own security checks, which is precisely what registering a new,
+   * unvetted companion would ask the gateway to do.
+   */
+  private static void mountCompanionDiscovery(Vertx vertx, JsonObject config, Router router, BodyHandler bodyHandler, Delegator delegator, DiagramRegistry registry) {
+    if (!config.getBoolean("KROKI_ENABLE_COMPANION_DISCOVERY", false)) {
+      return;
+    }
+    SafeMode safeMode = SafeMode.get(config.getString("KROKI_SAFE_MODE", "secure"), SafeMode.SECURE);
+    if (safeMode == SafeMode.SECURE) {
+      logger.warn("KROKI_ENABLE_COMPANION_DISCOVERY is enabled but KROKI_SAFE_MODE is SECURE (the default): " +
+        "companion service discovery stays disabled. Set KROKI_SAFE_MODE to SAFE or UNSAFE to allow it.");
+      return;
+    }
+    String token = config.getString("KROKI_COMPANION_REGISTRATION_TOKEN");
+    if (token == null || token.isEmpty()) {
+      logger.warn("KROKI_ENABLE_COMPANION_DISCOVERY is enabled without KROKI_COMPANION_REGISTRATION_TOKEN: " +
+        "the /services registration API is unauthenticated, only expose it on a trusted network.");
+    }
+    long heartbeatTtlMs = config.getLong("KROKI_COMPANION_HEARTBEAT_TTL_MS", 90_000L);
+
+    // additional hostnames to reject as a companion's host, on top of the built-in cloud metadata denylist
+    Set<String> extraBlockedHosts = new LinkedHashSet<>();
+    String blockedHostsVar = config.getString("KROKI_COMPANION_BLOCKED_HOSTS");
+    if (blockedHostsVar != null) {
+      Arrays.stream(blockedHostsVar.split(","))
+        .map(String::trim)
+        .filter(s -> !s.isEmpty())
+        .forEach(extraBlockedHosts::add);
+    }
+
+    CompanionRegistry companionRegistry = new CompanionRegistry(registry, delegator, extraBlockedHosts);
+    CompanionServiceHandler serviceHandler = new CompanionServiceHandler(companionRegistry);
+
+    if (token != null && !token.isEmpty()) {
+      router.route("/services*").handler(new CompanionAuthHandler(token));
+    }
+    router.post("/services")
+      .handler(bodyHandler)
+      .handler(serviceHandler.createRegister());
+    router.put("/services/:name/heartbeat")
+      .handler(serviceHandler.createHeartbeat());
+    router.get("/services/:name")
+      .handler(serviceHandler.createGet());
+    router.get("/services")
+      .handler(serviceHandler.createList());
+    router.delete("/services/:name")
+      .handler(serviceHandler.createUnregister());
+
+    long sweepIntervalMs = config.getLong("KROKI_COMPANION_HEARTBEAT_SWEEP_INTERVAL_MS", Math.max(heartbeatTtlMs / 3, 5_000L));
+    vertx.setPeriodic(sweepIntervalMs, timerId -> {
+      List<String> expired = companionRegistry.sweepExpired(Duration.ofMillis(heartbeatTtlMs));
+      if (!expired.isEmpty()) {
+        logger.info("Evicted companion service(s) that missed their heartbeat deadline: {}", expired);
+      }
+    });
   }
 
   private static void setPemKeyCertOptions(JsonObject config, HttpServerOptions serverOptions, boolean enableSSL) {

--- a/server/src/main/java/io/kroki/server/registry/CompanionAuthHandler.java
+++ b/server/src/main/java/io/kroki/server/registry/CompanionAuthHandler.java
@@ -1,0 +1,42 @@
+package io.kroki.server.registry;
+
+import io.vertx.core.Handler;
+import io.vertx.ext.web.RoutingContext;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+
+/**
+ * Guards the {@code /services} management API with a shared-secret bearer token, when configured
+ * via {@code KROKI_COMPANION_REGISTRATION_TOKEN}. Without a token configured, any client able to
+ * reach the gateway can register a companion service, which is only appropriate on a trusted
+ * network (e.g. a private Docker/Kubernetes network with no external route to the gateway).
+ */
+public class CompanionAuthHandler implements Handler<RoutingContext> {
+
+  private static final String BEARER_PREFIX = "Bearer ";
+
+  private final String token;
+
+  public CompanionAuthHandler(String token) {
+    this.token = token;
+  }
+
+  @Override
+  public void handle(RoutingContext routingContext) {
+    String authorization = routingContext.request().getHeader("Authorization");
+    if (authorization != null && authorization.startsWith(BEARER_PREFIX) && constantTimeEquals(authorization.substring(BEARER_PREFIX.length()), token)) {
+      routingContext.next();
+      return;
+    }
+    routingContext.response()
+      .setStatusCode(401)
+      .putHeader("WWW-Authenticate", "Bearer")
+      .putHeader("Content-Type", "application/json")
+      .end("{\"error\":\"Missing or invalid bearer token.\"}");
+  }
+
+  private static boolean constantTimeEquals(String a, String b) {
+    return MessageDigest.isEqual(a.getBytes(StandardCharsets.UTF_8), b.getBytes(StandardCharsets.UTF_8));
+  }
+}

--- a/server/src/main/java/io/kroki/server/registry/CompanionDiagramService.java
+++ b/server/src/main/java/io/kroki/server/registry/CompanionDiagramService.java
@@ -1,0 +1,66 @@
+package io.kroki.server.registry;
+
+import io.kroki.server.action.Delegator;
+import io.kroki.server.decode.DiagramSource;
+import io.kroki.server.decode.SourceDecoder;
+import io.kroki.server.error.DecodeException;
+import io.kroki.server.format.FileFormat;
+import io.kroki.server.service.DiagramService;
+import io.vertx.core.Future;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.client.HttpResponse;
+
+import java.util.List;
+
+/**
+ * Delegates diagram conversion to a companion service registered dynamically at runtime
+ * (see issue #1423), using the same wire protocol as the built-in companion containers
+ * (e.g. {@link io.kroki.server.service.Bpmn}): {@code POST /<name>/<format>} with the
+ * decoded source as the request body.
+ */
+public class CompanionDiagramService implements DiagramService {
+
+  private final Delegator delegator;
+  private final String host;
+  private final int port;
+  private final String version;
+  private final List<FileFormat> formats;
+  private final SourceDecoder sourceDecoder;
+
+  public CompanionDiagramService(Delegator delegator, String host, int port, String version, List<FileFormat> formats) {
+    this.delegator = delegator;
+    this.host = host;
+    this.port = port;
+    this.version = version;
+    this.formats = formats;
+    this.sourceDecoder = new SourceDecoder() {
+      @Override
+      public String decode(String encoded) throws DecodeException {
+        return DiagramSource.decode(encoded);
+      }
+    };
+  }
+
+  @Override
+  public List<FileFormat> getSupportedFormats() {
+    return formats;
+  }
+
+  @Override
+  public SourceDecoder getSourceDecoder() {
+    return sourceDecoder;
+  }
+
+  @Override
+  public String getVersion() {
+    return version;
+  }
+
+  @Override
+  public Future<Buffer> convert(String sourceDecoded, String serviceName, FileFormat fileFormat, JsonObject options) {
+    String requestURI = "/" + serviceName + "/" + fileFormat.getName();
+    Future<HttpResponse<Buffer>> httpResponseFuture = this.delegator.delegate(host, port, requestURI, sourceDecoded, options);
+    return Delegator.handle(host, port, requestURI, httpResponseFuture);
+  }
+}

--- a/server/src/main/java/io/kroki/server/registry/CompanionRegistration.java
+++ b/server/src/main/java/io/kroki/server/registry/CompanionRegistration.java
@@ -1,0 +1,75 @@
+package io.kroki.server.registry;
+
+import io.kroki.server.format.FileFormat;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+
+import java.time.Instant;
+import java.util.List;
+
+/**
+ * A companion service registered dynamically with the gateway (see issue #1423).
+ */
+public class CompanionRegistration {
+
+  private final String name;
+  private final String version;
+  private final List<FileFormat> formats;
+  private final String host;
+  private final int port;
+  private final Instant createdAt;
+  private volatile Instant updatedAt;
+  private volatile Instant lastActivityAt;
+
+  public CompanionRegistration(String name, String version, List<FileFormat> formats, String host, int port, Instant now) {
+    this.name = name;
+    this.version = version;
+    this.formats = formats;
+    this.host = host;
+    this.port = port;
+    this.createdAt = now;
+    this.updatedAt = now;
+    this.lastActivityAt = now;
+  }
+
+  public void heartbeat(Instant now) {
+    this.updatedAt = now;
+    this.lastActivityAt = now;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public String getVersion() {
+    return version;
+  }
+
+  public List<FileFormat> getFormats() {
+    return formats;
+  }
+
+  public String getHost() {
+    return host;
+  }
+
+  public int getPort() {
+    return port;
+  }
+
+  public Instant getLastActivityAt() {
+    return lastActivityAt;
+  }
+
+  public JsonObject toJson() {
+    JsonArray formatNames = new JsonArray();
+    formats.forEach(fileFormat -> formatNames.add(fileFormat.getName()));
+    return new JsonObject()
+      .put("name", name)
+      .put("version", version)
+      .put("formats", formatNames)
+      .put("created_at", createdAt.toString())
+      .put("updated_at", updatedAt.toString())
+      .put("last_activity_at", lastActivityAt.toString());
+  }
+}

--- a/server/src/main/java/io/kroki/server/registry/CompanionRegistry.java
+++ b/server/src/main/java/io/kroki/server/registry/CompanionRegistry.java
@@ -1,0 +1,222 @@
+package io.kroki.server.registry;
+
+import io.kroki.server.action.Delegator;
+import io.kroki.server.error.BadRequestException;
+import io.kroki.server.format.FileFormat;
+import io.kroki.server.service.DiagramRegistry;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+/**
+ * In-memory registry of companion services registered dynamically at runtime (see issue #1423).
+ *
+ * <p>A companion service registers itself (POST /services), refreshes its registration with a
+ * heartbeat (PUT /services/:name/heartbeat), and is evicted (routes removed) either explicitly
+ * or after missing its heartbeat deadline for longer than the configured TTL. Since Kroki is
+ * stateless, the registry does not survive a restart: a companion is expected to register again.
+ */
+public class CompanionRegistry {
+
+  // Names that would collide with routes mounted directly on the router, outside DiagramRegistry.
+  private static final Set<String> RESERVED_NAMES = Set.of("health", "healthz", "metrics", "services", "v1");
+  // Cloud metadata hostnames that aren't IP literals, so isBlockedHost()'s address-range check
+  // below can't catch them (e.g. GCP resolves this name to its link-local metadata IP via DNS).
+  // Extendable per deployment via KROKI_COMPANION_BLOCKED_HOSTS (see Server.mountCompanionDiscovery).
+  private static final Set<String> DEFAULT_BLOCKED_HOSTNAMES = Set.of("metadata.google.internal");
+  private static final Pattern IPV4_LITERAL = Pattern.compile("^\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}$");
+  private static final Pattern NAME_PATTERN = Pattern.compile("^[a-z][a-z0-9]{1,31}$");
+
+  // Mutated only from the Vert.x event loop thread (request handlers and the heartbeat sweep
+  // timer all run on the same verticle context), like the rest of DiagramRegistry.
+  private final Map<String, CompanionRegistration> registrations = new HashMap<>();
+  private final DiagramRegistry diagramRegistry;
+  private final Delegator delegator;
+  private final Set<String> blockedHostnames;
+
+  public CompanionRegistry(DiagramRegistry diagramRegistry, Delegator delegator) {
+    this(diagramRegistry, delegator, Set.of());
+  }
+
+  /**
+   * @param extraBlockedHostnames additional hostnames to reject as a companion's {@code host},
+   *                              on top of the built-in cloud metadata denylist (see
+   *                              {@code KROKI_COMPANION_BLOCKED_HOSTS})
+   */
+  public CompanionRegistry(DiagramRegistry diagramRegistry, Delegator delegator, Set<String> extraBlockedHostnames) {
+    this.diagramRegistry = diagramRegistry;
+    this.delegator = delegator;
+    Set<String> merged = new HashSet<>(DEFAULT_BLOCKED_HOSTNAMES);
+    for (String hostname : extraBlockedHostnames) {
+      merged.add(hostname.trim().toLowerCase());
+    }
+    this.blockedHostnames = Set.copyOf(merged);
+  }
+
+  /**
+   * Registers a new companion service and mounts its diagram routes.
+   *
+   * @param payload the registration request body
+   * @return the resulting registration
+   * @throws BadRequestException with status 400 if the payload is invalid, or 422 if the name is already taken
+   */
+  public CompanionRegistration register(JsonObject payload) {
+    String name = requireString(payload, "name");
+    if (!NAME_PATTERN.matcher(name).matches()) {
+      throw new BadRequestException("Field name must match " + NAME_PATTERN.pattern() + ", got: '" + name + "'", 400);
+    }
+    if (RESERVED_NAMES.contains(name) || diagramRegistry.isRegistered(name) || registrations.containsKey(name)) {
+      throw new BadRequestException("A service named '" + name + "' is already registered.", 422);
+    }
+    String version = requireString(payload, "version");
+    List<FileFormat> formats = requireFormats(payload);
+    String host = requireString(payload, "host");
+    if (isBlockedHost(host)) {
+      throw new BadRequestException("Field host must not target a cloud metadata endpoint or a loopback/link-local/private address, got: '" + host + "'", 400);
+    }
+    int port = requirePort(payload);
+
+    Instant now = Instant.now();
+    CompanionRegistration registration = new CompanionRegistration(name, version, formats, host, port, now);
+    diagramRegistry.register(new CompanionDiagramService(delegator, host, port, version, formats), name);
+    registrations.put(name, registration);
+    return registration;
+  }
+
+  /**
+   * Refreshes the heartbeat of a registered companion service.
+   *
+   * @param name the diagram type name
+   * @return the registration if found, empty otherwise (the caller should register again)
+   */
+  public Optional<CompanionRegistration> heartbeat(String name) {
+    CompanionRegistration registration = registrations.get(name);
+    if (registration == null) {
+      return Optional.empty();
+    }
+    registration.heartbeat(Instant.now());
+    return Optional.of(registration);
+  }
+
+  public Optional<CompanionRegistration> get(String name) {
+    return Optional.ofNullable(registrations.get(name));
+  }
+
+  public List<CompanionRegistration> list() {
+    return new ArrayList<>(registrations.values());
+  }
+
+  /**
+   * Explicitly unregisters a companion service (e.g. on graceful shutdown), removing its routes immediately.
+   *
+   * @param name the diagram type name
+   * @return true if a registration was removed, false if none existed
+   */
+  public boolean unregister(String name) {
+    if (registrations.remove(name) == null) {
+      return false;
+    }
+    diagramRegistry.unregister(name);
+    return true;
+  }
+
+  /**
+   * Evicts every companion service that has not sent a heartbeat within the given TTL.
+   *
+   * @param ttl the maximum allowed time since the last heartbeat
+   * @return the names of the evicted services
+   */
+  public List<String> sweepExpired(Duration ttl) {
+    Instant deadline = Instant.now().minus(ttl);
+    List<String> expired = registrations.values().stream()
+      .filter(registration -> registration.getLastActivityAt().isBefore(deadline))
+      .map(CompanionRegistration::getName)
+      .collect(Collectors.toList());
+    for (String name : expired) {
+      registrations.remove(name);
+      diagramRegistry.unregister(name);
+    }
+    return expired;
+  }
+
+  /**
+   * Best-effort check that {@code host} isn't a loopback, link-local (which covers every major
+   * cloud provider's instance-metadata IP, e.g. AWS/Azure/GCP's 169.254.169.254 and AWS ECS's
+   * 169.254.170.2) or private address, plus a small denylist of non-IP metadata hostnames.
+   *
+   * <p>Deliberately does not resolve arbitrary hostnames via DNS (that would block the event loop
+   * and cannot itself be trusted against DNS rebinding), so this only catches literal IP addresses
+   * and the explicitly configured hostnames. It is defense-in-depth, not a substitute for only
+   * enabling companion discovery on a trusted network.
+   */
+  private boolean isBlockedHost(String host) {
+    String normalized = host.trim().toLowerCase();
+    while (normalized.endsWith(".")) {
+      normalized = normalized.substring(0, normalized.length() - 1);
+    }
+    if (blockedHostnames.contains(normalized)) {
+      return true;
+    }
+    boolean looksLikeIpLiteral = normalized.contains(":") || IPV4_LITERAL.matcher(normalized).matches();
+    if (!looksLikeIpLiteral) {
+      return false;
+    }
+    try {
+      // for a literal IP address, getByName() only parses the string: no DNS lookup is performed
+      InetAddress address = InetAddress.getByName(normalized);
+      return address.isLoopbackAddress() || address.isLinkLocalAddress() || address.isSiteLocalAddress() || address.isAnyLocalAddress();
+    } catch (UnknownHostException e) {
+      // malformed literal, let it fail later when actually connecting
+      return false;
+    }
+  }
+
+  private static String requireString(JsonObject payload, String field) {
+    String value = payload.getString(field);
+    if (value == null || value.trim().isEmpty()) {
+      throw new BadRequestException("Field " + field + " must not be empty.", 400);
+    }
+    return value.trim();
+  }
+
+  private static List<FileFormat> requireFormats(JsonObject payload) {
+    Object value = payload.getValue("formats");
+    if (!(value instanceof JsonArray) || ((JsonArray) value).isEmpty()) {
+      throw new BadRequestException("Field formats must be a non-empty array.", 400);
+    }
+    List<FileFormat> formats = new ArrayList<>();
+    for (Object formatValue : (JsonArray) value) {
+      FileFormat fileFormat = formatValue instanceof String ? FileFormat.get((String) formatValue) : null;
+      if (fileFormat == null) {
+        throw new BadRequestException("Field formats contains an unsupported format: '" + formatValue + "'", 400);
+      }
+      formats.add(fileFormat);
+    }
+    return formats;
+  }
+
+  private static int requirePort(JsonObject payload) {
+    Object value = payload.getValue("port");
+    if (!(value instanceof Number)) {
+      throw new BadRequestException("Field port must be an integer between 1 and 65535.", 400);
+    }
+    int port = ((Number) value).intValue();
+    if (port < 1 || port > 65535) {
+      throw new BadRequestException("Field port must be an integer between 1 and 65535.", 400);
+    }
+    return port;
+  }
+}

--- a/server/src/main/java/io/kroki/server/registry/CompanionServiceHandler.java
+++ b/server/src/main/java/io/kroki/server/registry/CompanionServiceHandler.java
@@ -1,0 +1,108 @@
+package io.kroki.server.registry;
+
+import io.kroki.server.error.BadRequestException;
+import io.vertx.core.Handler;
+import io.vertx.core.http.HttpHeaders;
+import io.vertx.core.json.DecodeException;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.RoutingContext;
+
+/**
+ * REST API used by companion containers to register themselves, heartbeat, and look up
+ * registrations (see issue #1423). Mounted under {@code /services} only when
+ * {@code KROKI_ENABLE_COMPANION_DISCOVERY} is enabled.
+ */
+public class CompanionServiceHandler {
+
+  private final CompanionRegistry companionRegistry;
+
+  public CompanionServiceHandler(CompanionRegistry companionRegistry) {
+    this.companionRegistry = companionRegistry;
+  }
+
+  public Handler<RoutingContext> createRegister() {
+    return routingContext -> {
+      JsonObject payload = readJsonBody(routingContext);
+      if (payload == null) {
+        return;
+      }
+      CompanionRegistration registration = companionRegistry.register(payload);
+      routingContext.response()
+        .setStatusCode(201)
+        .putHeader(HttpHeaders.CONTENT_TYPE, "application/json")
+        .putHeader(HttpHeaders.LOCATION, "/services/" + registration.getName())
+        .end(registration.toJson().encode());
+    };
+  }
+
+  public Handler<RoutingContext> createHeartbeat() {
+    return routingContext -> {
+      String name = routingContext.pathParam("name");
+      companionRegistry.heartbeat(name).ifPresentOrElse(
+        registration -> routingContext.response()
+          .setStatusCode(200)
+          .putHeader(HttpHeaders.CONTENT_TYPE, "application/json")
+          .end(registration.toJson().encode()),
+        () -> {
+          JsonObject notFound = new JsonObject()
+            .put("error", "Service '" + name + "' is not registered.")
+            .put("_links", new JsonObject().put("register", new JsonObject()
+              .put("href", "/services")
+              .put("method", "POST")));
+          routingContext.response()
+            .setStatusCode(404)
+            .putHeader(HttpHeaders.CONTENT_TYPE, "application/json")
+            .end(notFound.encode());
+        }
+      );
+    };
+  }
+
+  public Handler<RoutingContext> createGet() {
+    return routingContext -> {
+      String name = routingContext.pathParam("name");
+      companionRegistry.get(name).ifPresentOrElse(
+        registration -> routingContext.response()
+          .putHeader(HttpHeaders.CONTENT_TYPE, "application/json")
+          .end(registration.toJson().encode()),
+        () -> routingContext.fail(404)
+      );
+    };
+  }
+
+  public Handler<RoutingContext> createList() {
+    return routingContext -> {
+      JsonArray services = new JsonArray();
+      companionRegistry.list().forEach(registration -> services.add(registration.toJson()));
+      routingContext.response()
+        .putHeader(HttpHeaders.CONTENT_TYPE, "application/json")
+        .end(services.encode());
+    };
+  }
+
+  public Handler<RoutingContext> createUnregister() {
+    return routingContext -> {
+      String name = routingContext.pathParam("name");
+      if (companionRegistry.unregister(name)) {
+        routingContext.response().setStatusCode(204).end();
+      } else {
+        routingContext.fail(404);
+      }
+    };
+  }
+
+  private JsonObject readJsonBody(RoutingContext routingContext) {
+    String bodyAsString = routingContext.body().asString();
+    if (bodyAsString == null || bodyAsString.trim().isEmpty()) {
+      routingContext.fail(new BadRequestException("Request body must not be empty."));
+      return null;
+    }
+    try {
+      return new JsonObject(bodyAsString);
+    } catch (DecodeException e) {
+      routingContext.fail(new BadRequestException("Request body must be a valid JSON object.", e));
+      return null;
+    }
+  }
+}

--- a/server/src/main/java/io/kroki/server/service/DiagramRegistry.java
+++ b/server/src/main/java/io/kroki/server/service/DiagramRegistry.java
@@ -4,9 +4,11 @@ import io.kroki.server.error.MethodNotAllowedException;
 import io.kroki.server.error.UnsupportedFormatException;
 import io.kroki.server.response.Caching;
 import io.vertx.core.http.HttpMethod;
+import io.vertx.ext.web.Route;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.handler.BodyHandler;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -15,7 +17,17 @@ import java.util.stream.Collectors;
 
 public class DiagramRegistry {
 
-  private final Map<String, DiagramHandler> registry = new HashMap<>();
+  private static class Entry {
+    final DiagramHandler handler;
+    final List<Route> routes;
+
+    Entry(DiagramHandler handler, List<Route> routes) {
+      this.handler = handler;
+      this.routes = routes;
+    }
+  }
+
+  private final Map<String, Entry> registry = new HashMap<>();
   private final Router router;
   private final BodyHandler bodyHandler;
 
@@ -27,23 +39,23 @@ public class DiagramRegistry {
   public void register(DiagramService diagramService, String... names) {
     DiagramHandler diagramHandler = new DiagramHandler(diagramService, new Caching(diagramService.getVersion()));
     for (String name : names) {
-      registry.put(name, diagramHandler);
-      router.get("/" + name + "/:output_format/:source_encoded")
+      List<Route> routes = new ArrayList<>();
+      routes.add(router.get("/" + name + "/:output_format/:source_encoded")
         .handler(diagramHandler.createRequestReceived(name))
-        .handler(diagramHandler.createGet(name));
-      router.route("/" + name)
+        .handler(diagramHandler.createGet(name)));
+      routes.add(router.route("/" + name)
         .handler(event -> {
           if (HttpMethod.POST.equals(event.request().method())) {
             event.next();
             return;
           }
           event.fail(405, new MethodNotAllowedException(List.of("POST")));
-        });
-      router.post("/" + name)
+        }));
+      routes.add(router.post("/" + name)
         .handler(bodyHandler)
         .handler(diagramHandler.createRequestReceived(name))
-        .handler(diagramHandler.createPost(name));
-      router.route("/" + name + "/:output_format")
+        .handler(diagramHandler.createPost(name)));
+      routes.add(router.route("/" + name + "/:output_format")
         .handler(event -> {
           if (HttpMethod.POST.equals(event.request().method())) {
             event.next();
@@ -57,16 +69,40 @@ public class DiagramRegistry {
             return;
           }
           event.fail(405, new MethodNotAllowedException(List.of("POST")));
-        });
-      router.post("/" + name + "/:output_format")
+        }));
+      routes.add(router.post("/" + name + "/:output_format")
         .handler(bodyHandler)
         .handler(diagramHandler.createRequestReceived(name))
-        .handler(diagramHandler.createPost(name));
+        .handler(diagramHandler.createPost(name)));
+      registry.put(name, new Entry(diagramHandler, routes));
     }
   }
 
+  /**
+   * Removes a previously registered diagram type, disabling its routes.
+   * Used to evict a companion service that unregistered or missed its heartbeat deadline.
+   *
+   * @param name the diagram type name
+   * @return true if a registration was removed, false if none existed
+   */
+  public boolean unregister(String name) {
+    Entry entry = registry.remove(name);
+    if (entry == null) {
+      return false;
+    }
+    for (Route route : entry.routes) {
+      route.remove();
+    }
+    return true;
+  }
+
+  public boolean isRegistered(String name) {
+    return registry.containsKey(name);
+  }
+
   public DiagramHandler get(String name) {
-    return registry.get(name);
+    Entry entry = registry.get(name);
+    return entry != null ? entry.handler : null;
   }
 
   public Set<String> names() {
@@ -76,7 +112,7 @@ public class DiagramRegistry {
   public Map<String, String> getVersions() {
     return registry.entrySet().stream().map(registryEntry -> {
       String diagramName = registryEntry.getKey();
-      String diagramVersion = registryEntry.getValue().getService().getVersion();
+      String diagramVersion = registryEntry.getValue().handler.getService().getVersion();
       return Map.entry(diagramName, diagramVersion);
     }).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
   }

--- a/server/src/main/java/io/kroki/server/service/HealthHandler.java
+++ b/server/src/main/java/io/kroki/server/service/HealthHandler.java
@@ -10,25 +10,35 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Supplier;
 
 public class HealthHandler {
 
   private final String krokiVersionNumber;
   private final String krokiBuildHash;
-  private final List<ServiceVersion> serviceVersions;
+  private final Supplier<Map<String, String>> versionsSupplier;
 
   public HealthHandler(Map<String, String> versions) {
-    this(versions, null);
+    this(() -> versions, null);
+  }
+
+  public HealthHandler(Supplier<Map<String, String>> versionsSupplier) {
+    this(versionsSupplier, null);
   }
 
   public HealthHandler(Map<String, String> versions, KrokiBlockedThreadChecker blockedThreadChecker) {
+    this(() -> versions, blockedThreadChecker);
+  }
+
+  /**
+   * @param versionsSupplier queried on every call (rather than a fixed snapshot) so that diagram
+   *                          types registered or evicted at runtime (see issue #1423) are reflected
+   *                          immediately, both in the /health response and on the homepage.
+   */
+  public HealthHandler(Supplier<Map<String, String>> versionsSupplier, KrokiBlockedThreadChecker blockedThreadChecker) {
     krokiVersionNumber = Main.getApplicationProperty("app.version", "");
     krokiBuildHash = Main.getApplicationProperty("app.sha1", "");
-    serviceVersions = new ArrayList<>();
-    // QUESTION: should we dynamically fetch the versions ?
-    for (Map.Entry<String, String> entry : versions.entrySet()) {
-      serviceVersions.add(new ServiceVersion(entry.getKey(), entry.getValue()));
-    }
+    this.versionsSupplier = versionsSupplier;
   }
 
   public Handler<RoutingContext> create() {
@@ -41,7 +51,7 @@ public class HealthHandler {
       krokiVersion.put("build_hash", krokiBuildHash);
       versions.put("kroki", krokiVersion);
       data.put("version", versions);
-      for (ServiceVersion serviceVersion : serviceVersions) {
+      for (ServiceVersion serviceVersion : getServiceVersions()) {
         versions.put(serviceVersion.getService(), serviceVersion.getVersion());
       }
       routingContext
@@ -60,6 +70,10 @@ public class HealthHandler {
   }
 
   public List<ServiceVersion> getServiceVersions() {
+    List<ServiceVersion> serviceVersions = new ArrayList<>();
+    for (Map.Entry<String, String> entry : versionsSupplier.get().entrySet()) {
+      serviceVersions.add(new ServiceVersion(entry.getKey(), entry.getValue()));
+    }
     return serviceVersions;
   }
 }

--- a/server/src/main/java/io/kroki/server/service/HelloHandler.java
+++ b/server/src/main/java/io/kroki/server/service/HelloHandler.java
@@ -6,16 +6,26 @@ import io.vertx.core.http.HttpHeaders;
 import io.vertx.ext.web.RoutingContext;
 
 import java.util.List;
+import java.util.function.Supplier;
 
 public class HelloHandler {
 
   private final String rowTemplate;
   private final String tableTemplate;
   private final String pageTemplate;
-  private final List<ServiceVersion> serviceVersions;
+  private final Supplier<List<ServiceVersion>> serviceVersionsSupplier;
 
   public HelloHandler(Vertx vertx, List<ServiceVersion> serviceVersions, String krokiVersionNumber, String krokiBuildHash) {
-    this.serviceVersions = serviceVersions;
+    this(vertx, () -> serviceVersions, krokiVersionNumber, krokiBuildHash);
+  }
+
+  /**
+   * @param serviceVersionsSupplier queried on every request (rather than a fixed snapshot) so
+   *                                 that diagram types registered or evicted at runtime (see
+   *                                 issue #1423) show up on the homepage immediately.
+   */
+  public HelloHandler(Vertx vertx, Supplier<List<ServiceVersion>> serviceVersionsSupplier, String krokiVersionNumber, String krokiBuildHash) {
+    this.serviceVersionsSupplier = serviceVersionsSupplier;
     this.rowTemplate = vertx.fileSystem().readFileBlocking("web/version_row.html").toString();
     this.tableTemplate = vertx.fileSystem().readFileBlocking("web/version_table.html").toString();
     String stylesheet = vertx.fileSystem().readFileBlocking("web/root/css/main.css").toString();
@@ -29,7 +39,7 @@ public class HelloHandler {
 
   public Handler<RoutingContext> create() {
     return routingContext -> {
-      String versionsTable = generateVersionsTable(serviceVersions);
+      String versionsTable = generateVersionsTable(serviceVersionsSupplier.get());
       routingContext
         .response()
         .putHeader(HttpHeaders.CONTENT_TYPE, "text/html")

--- a/server/src/test/java/io/kroki/server/registry/CompanionDiscoveryServerTest.java
+++ b/server/src/test/java/io/kroki/server/registry/CompanionDiscoveryServerTest.java
@@ -1,0 +1,266 @@
+package io.kroki.server.registry;
+
+import io.kroki.server.Server;
+import io.vertx.core.DeploymentOptions;
+import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpServer;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.client.HttpResponse;
+import io.vertx.ext.web.client.WebClient;
+import io.vertx.junit5.VertxExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(VertxExtension.class)
+class CompanionDiscoveryServerTest {
+
+  private static int getAvailablePort() throws IOException {
+    try (ServerSocket socket = new ServerSocket(0)) {
+      return socket.getLocalPort();
+    }
+  }
+
+  private static JsonObject registrationPayload(String name, int companionPort) {
+    return new JsonObject()
+      .put("name", name)
+      .put("version", "1.2.3")
+      .put("formats", new JsonArray().add("svg"))
+      .put("host", "localhost")
+      .put("port", companionPort);
+  }
+
+  /**
+   * Discovery enabled with a non-SECURE safe mode: KROKI_SAFE_MODE defaults to SECURE (see
+   * should_not_mount_services_routes_under_the_default_safe_mode_even_if_discovery_is_enabled),
+   * which would otherwise keep discovery disabled regardless of KROKI_ENABLE_COMPANION_DISCOVERY.
+   */
+  private static JsonObject discoveryEnabledConfig(int krokiPort) {
+    return new JsonObject()
+      .put("KROKI_LISTEN", "127.0.0.1:" + krokiPort)
+      .put("KROKI_ENABLE_COMPANION_DISCOVERY", true)
+      .put("KROKI_SAFE_MODE", "SAFE");
+  }
+
+  private void startFakeCompanion(Vertx vertx, int port) throws TimeoutException {
+    HttpServer companion = vertx.createHttpServer();
+    companion.requestHandler(req -> req.body().onSuccess(body ->
+      req.response().setStatusCode(200).end("companion-received:" + body.toString())));
+    companion.listen(port, "localhost").await(5, TimeUnit.SECONDS);
+  }
+
+  @Test
+  void should_register_and_delegate_to_a_companion_service(Vertx vertx) throws IOException, TimeoutException {
+    int krokiPort = getAvailablePort();
+    int companionPort = getAvailablePort();
+    startFakeCompanion(vertx, companionPort);
+
+    JsonObject config = discoveryEnabledConfig(krokiPort);
+    vertx.deployVerticle(new Server(), new DeploymentOptions().setConfig(config)).await(5, TimeUnit.SECONDS);
+    WebClient client = WebClient.create(vertx);
+
+    HttpResponse<Buffer> registerResponse = client.post(krokiPort, "localhost", "/services")
+      .sendJsonObject(registrationPayload("mscgen", companionPort))
+      .await(5, TimeUnit.SECONDS);
+    assertThat(registerResponse.statusCode()).isEqualTo(201);
+    assertThat(registerResponse.bodyAsJsonObject().getString("name")).isEqualTo("mscgen");
+
+    HttpResponse<Buffer> convertResponse = client.post(krokiPort, "localhost", "/mscgen/svg")
+      .sendBuffer(Buffer.buffer("msc { a -> b; }"))
+      .await(5, TimeUnit.SECONDS);
+    assertThat(convertResponse.statusCode()).isEqualTo(200);
+    assertThat(convertResponse.bodyAsString()).isEqualTo("companion-received:msc { a -> b; }");
+
+    HttpResponse<Buffer> heartbeatResponse = client.put(krokiPort, "localhost", "/services/mscgen/heartbeat")
+      .send()
+      .await(5, TimeUnit.SECONDS);
+    assertThat(heartbeatResponse.statusCode()).isEqualTo(200);
+
+    HttpResponse<Buffer> getResponse = client.get(krokiPort, "localhost", "/services/mscgen")
+      .send()
+      .await(5, TimeUnit.SECONDS);
+    assertThat(getResponse.statusCode()).isEqualTo(200);
+    assertThat(getResponse.bodyAsJsonObject().getJsonArray("formats")).containsExactly("svg");
+
+    HttpResponse<Buffer> unregisterResponse = client.delete(krokiPort, "localhost", "/services/mscgen")
+      .send()
+      .await(5, TimeUnit.SECONDS);
+    assertThat(unregisterResponse.statusCode()).isEqualTo(204);
+
+    HttpResponse<Buffer> afterUnregisterResponse = client.post(krokiPort, "localhost", "/mscgen/svg")
+      .sendBuffer(Buffer.buffer("msc { a -> b; }"))
+      .await(5, TimeUnit.SECONDS);
+    assertThat(afterUnregisterResponse.statusCode()).isEqualTo(404);
+  }
+
+  @Test
+  void should_expose_a_registered_companion_in_health_and_homepage(Vertx vertx) throws IOException, TimeoutException {
+    int krokiPort = getAvailablePort();
+    int companionPort = getAvailablePort();
+    startFakeCompanion(vertx, companionPort);
+
+    JsonObject config = discoveryEnabledConfig(krokiPort);
+    vertx.deployVerticle(new Server(), new DeploymentOptions().setConfig(config)).await(5, TimeUnit.SECONDS);
+    WebClient client = WebClient.create(vertx);
+
+    // not registered yet: absent from both endpoints
+    HttpResponse<Buffer> healthBefore = client.get(krokiPort, "localhost", "/health").send().await(5, TimeUnit.SECONDS);
+    assertThat(healthBefore.bodyAsJsonObject().getJsonObject("version").containsKey("mscgen")).isFalse();
+
+    HttpResponse<Buffer> registerResponse = client.post(krokiPort, "localhost", "/services")
+      .sendJsonObject(registrationPayload("mscgen", companionPort))
+      .await(5, TimeUnit.SECONDS);
+    assertThat(registerResponse.statusCode()).isEqualTo(201);
+
+    HttpResponse<Buffer> healthAfter = client.get(krokiPort, "localhost", "/health").send().await(5, TimeUnit.SECONDS);
+    assertThat(healthAfter.bodyAsJsonObject().getJsonObject("version").getString("mscgen")).isEqualTo("1.2.3");
+
+    HttpResponse<Buffer> homepageAfter = client.get(krokiPort, "localhost", "/").send().await(5, TimeUnit.SECONDS);
+    assertThat(homepageAfter.bodyAsString()).contains("mscgen");
+
+    client.delete(krokiPort, "localhost", "/services/mscgen").send().await(5, TimeUnit.SECONDS);
+    HttpResponse<Buffer> healthAfterUnregister = client.get(krokiPort, "localhost", "/health").send().await(5, TimeUnit.SECONDS);
+    assertThat(healthAfterUnregister.bodyAsJsonObject().getJsonObject("version").containsKey("mscgen")).isFalse();
+  }
+
+  @Test
+  void should_reject_a_duplicate_registration(Vertx vertx) throws IOException, TimeoutException {
+    int krokiPort = getAvailablePort();
+    int companionPort = getAvailablePort();
+    startFakeCompanion(vertx, companionPort);
+
+    JsonObject config = discoveryEnabledConfig(krokiPort);
+    vertx.deployVerticle(new Server(), new DeploymentOptions().setConfig(config)).await(5, TimeUnit.SECONDS);
+    WebClient client = WebClient.create(vertx);
+
+    client.post(krokiPort, "localhost", "/services")
+      .sendJsonObject(registrationPayload("mscgen", companionPort))
+      .await(5, TimeUnit.SECONDS);
+    HttpResponse<Buffer> secondAttempt = client.post(krokiPort, "localhost", "/services")
+      .sendJsonObject(registrationPayload("mscgen", companionPort))
+      .await(5, TimeUnit.SECONDS);
+    assertThat(secondAttempt.statusCode()).isEqualTo(422);
+  }
+
+  @Test
+  void should_require_a_bearer_token_when_configured(Vertx vertx) throws IOException, TimeoutException {
+    int krokiPort = getAvailablePort();
+    int companionPort = getAvailablePort();
+    startFakeCompanion(vertx, companionPort);
+
+    JsonObject config = discoveryEnabledConfig(krokiPort)
+      .put("KROKI_COMPANION_REGISTRATION_TOKEN", "s3cr3t");
+    vertx.deployVerticle(new Server(), new DeploymentOptions().setConfig(config)).await(5, TimeUnit.SECONDS);
+    WebClient client = WebClient.create(vertx);
+
+    HttpResponse<Buffer> withoutToken = client.post(krokiPort, "localhost", "/services")
+      .sendJsonObject(registrationPayload("mscgen", companionPort))
+      .await(5, TimeUnit.SECONDS);
+    assertThat(withoutToken.statusCode()).isEqualTo(401);
+
+    HttpResponse<Buffer> withWrongToken = client.post(krokiPort, "localhost", "/services")
+      .putHeader("Authorization", "Bearer wrong")
+      .sendJsonObject(registrationPayload("mscgen", companionPort))
+      .await(5, TimeUnit.SECONDS);
+    assertThat(withWrongToken.statusCode()).isEqualTo(401);
+
+    HttpResponse<Buffer> withCorrectToken = client.post(krokiPort, "localhost", "/services")
+      .putHeader("Authorization", "Bearer s3cr3t")
+      .sendJsonObject(registrationPayload("mscgen", companionPort))
+      .await(5, TimeUnit.SECONDS);
+    assertThat(withCorrectToken.statusCode()).isEqualTo(201);
+  }
+
+  @Test
+  void should_evict_a_service_that_missed_its_heartbeat_deadline(Vertx vertx) throws IOException, TimeoutException, InterruptedException {
+    int krokiPort = getAvailablePort();
+    int companionPort = getAvailablePort();
+    startFakeCompanion(vertx, companionPort);
+
+    JsonObject config = discoveryEnabledConfig(krokiPort)
+      .put("KROKI_COMPANION_HEARTBEAT_TTL_MS", 200)
+      .put("KROKI_COMPANION_HEARTBEAT_SWEEP_INTERVAL_MS", 100);
+    vertx.deployVerticle(new Server(), new DeploymentOptions().setConfig(config)).await(5, TimeUnit.SECONDS);
+    WebClient client = WebClient.create(vertx);
+
+    client.post(krokiPort, "localhost", "/services")
+      .sendJsonObject(registrationPayload("mscgen", companionPort))
+      .await(5, TimeUnit.SECONDS);
+
+    // wait past the heartbeat TTL and the sweep interval for the eviction to run
+    Thread.sleep(1000);
+
+    HttpResponse<Buffer> afterExpiryResponse = client.get(krokiPort, "localhost", "/services/mscgen")
+      .send()
+      .await(5, TimeUnit.SECONDS);
+    assertThat(afterExpiryResponse.statusCode()).isEqualTo(404);
+  }
+
+  @Test
+  void should_not_mount_services_routes_when_discovery_is_disabled(Vertx vertx) throws IOException, TimeoutException {
+    int krokiPort = getAvailablePort();
+    JsonObject config = new JsonObject().put("KROKI_LISTEN", "127.0.0.1:" + krokiPort);
+    vertx.deployVerticle(new Server(), new DeploymentOptions().setConfig(config)).await(5, TimeUnit.SECONDS);
+    WebClient client = WebClient.create(vertx);
+
+    HttpResponse<Buffer> response = client.post(krokiPort, "localhost", "/services")
+      .sendJsonObject(registrationPayload("mscgen", 1234))
+      .await(5, TimeUnit.SECONDS);
+    assertThat(response.statusCode()).isEqualTo(404);
+  }
+
+  @Test
+  void should_not_mount_services_routes_under_the_default_safe_mode_even_if_discovery_is_enabled(Vertx vertx) throws IOException, TimeoutException {
+    int krokiPort = getAvailablePort();
+    // KROKI_SAFE_MODE deliberately left unset: it defaults to SECURE, same as kroki.io
+    JsonObject config = new JsonObject()
+      .put("KROKI_LISTEN", "127.0.0.1:" + krokiPort)
+      .put("KROKI_ENABLE_COMPANION_DISCOVERY", true);
+    vertx.deployVerticle(new Server(), new DeploymentOptions().setConfig(config)).await(5, TimeUnit.SECONDS);
+    WebClient client = WebClient.create(vertx);
+
+    HttpResponse<Buffer> response = client.post(krokiPort, "localhost", "/services")
+      .sendJsonObject(registrationPayload("mscgen", 1234))
+      .await(5, TimeUnit.SECONDS);
+    assertThat(response.statusCode()).isEqualTo(404);
+  }
+
+  @Test
+  void should_not_mount_services_routes_when_safe_mode_is_explicitly_secure(Vertx vertx) throws IOException, TimeoutException {
+    int krokiPort = getAvailablePort();
+    JsonObject config = new JsonObject()
+      .put("KROKI_LISTEN", "127.0.0.1:" + krokiPort)
+      .put("KROKI_ENABLE_COMPANION_DISCOVERY", true)
+      .put("KROKI_SAFE_MODE", "SECURE");
+    vertx.deployVerticle(new Server(), new DeploymentOptions().setConfig(config)).await(5, TimeUnit.SECONDS);
+    WebClient client = WebClient.create(vertx);
+
+    HttpResponse<Buffer> response = client.post(krokiPort, "localhost", "/services")
+      .sendJsonObject(registrationPayload("mscgen", 1234))
+      .await(5, TimeUnit.SECONDS);
+    assertThat(response.statusCode()).isEqualTo(404);
+  }
+
+  @Test
+  void should_mount_services_routes_when_safe_mode_is_not_secure(Vertx vertx) throws IOException, TimeoutException {
+    int krokiPort = getAvailablePort();
+    int companionPort = getAvailablePort();
+    startFakeCompanion(vertx, companionPort);
+    JsonObject config = discoveryEnabledConfig(krokiPort);
+    vertx.deployVerticle(new Server(), new DeploymentOptions().setConfig(config)).await(5, TimeUnit.SECONDS);
+    WebClient client = WebClient.create(vertx);
+
+    HttpResponse<Buffer> response = client.post(krokiPort, "localhost", "/services")
+      .sendJsonObject(registrationPayload("mscgen", companionPort))
+      .await(5, TimeUnit.SECONDS);
+    assertThat(response.statusCode()).isEqualTo(201);
+  }
+}

--- a/server/src/test/java/io/kroki/server/registry/CompanionRegistryTest.java
+++ b/server/src/test/java/io/kroki/server/registry/CompanionRegistryTest.java
@@ -1,0 +1,259 @@
+package io.kroki.server.registry;
+
+import io.kroki.server.action.Delegator;
+import io.kroki.server.decode.SourceDecoder;
+import io.kroki.server.error.BadRequestException;
+import io.kroki.server.format.FileFormat;
+import io.kroki.server.service.DiagramRegistry;
+import io.kroki.server.service.DiagramService;
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.Router;
+import io.vertx.ext.web.handler.BodyHandler;
+import io.vertx.junit5.VertxExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@ExtendWith(VertxExtension.class)
+class CompanionRegistryTest {
+
+  private CompanionRegistry companionRegistry;
+  private DiagramRegistry diagramRegistry;
+  private Vertx vertx;
+
+  @BeforeEach
+  void init(Vertx vertx) {
+    this.vertx = vertx;
+    Router router = Router.router(vertx);
+    diagramRegistry = new DiagramRegistry(router, BodyHandler.create(false));
+    companionRegistry = new CompanionRegistry(diagramRegistry, new Delegator(vertx));
+  }
+
+  private static JsonObject payload(String name) {
+    return new JsonObject()
+      .put("name", name)
+      .put("version", "1.2.3")
+      .put("formats", new JsonArray().add("png").add("svg"))
+      .put("host", "mscgen-companion")
+      .put("port", 8080);
+  }
+
+  @Test
+  void should_register_a_new_companion_service() {
+    CompanionRegistration registration = companionRegistry.register(payload("mscgen"));
+    assertThat(registration.getName()).isEqualTo("mscgen");
+    assertThat(registration.getVersion()).isEqualTo("1.2.3");
+    assertThat(diagramRegistry.isRegistered("mscgen")).isTrue();
+    assertThat(companionRegistry.get("mscgen")).isPresent();
+  }
+
+  @Test
+  void should_reject_registration_with_a_duplicate_name() {
+    companionRegistry.register(payload("mscgen"));
+    assertThatThrownBy(() -> companionRegistry.register(payload("mscgen")))
+      .isInstanceOf(BadRequestException.class)
+      .satisfies(e -> assertThat(((BadRequestException) e).getStatusCode()).isEqualTo(422));
+  }
+
+  @Test
+  void should_reject_registration_colliding_with_a_builtin_diagram_type() {
+    diagramRegistry.register(new FakeDiagramService(), "plantuml");
+    assertThatThrownBy(() -> companionRegistry.register(payload("plantuml")))
+      .isInstanceOf(BadRequestException.class)
+      .satisfies(e -> assertThat(((BadRequestException) e).getStatusCode()).isEqualTo(422));
+  }
+
+  @Test
+  void should_reject_registration_with_an_invalid_name() {
+    assertThatThrownBy(() -> companionRegistry.register(payload("MSCGEN")))
+      .isInstanceOf(BadRequestException.class)
+      .satisfies(e -> assertThat(((BadRequestException) e).getStatusCode()).isEqualTo(400));
+  }
+
+  @Test
+  void should_reject_registration_with_a_reserved_name() {
+    assertThatThrownBy(() -> companionRegistry.register(payload("services")))
+      .isInstanceOf(BadRequestException.class)
+      .satisfies(e -> assertThat(((BadRequestException) e).getStatusCode()).isEqualTo(422));
+  }
+
+  @Test
+  void should_reject_registration_with_an_unsupported_format() {
+    JsonObject payload = payload("mscgen").put("formats", new JsonArray().add("docx"));
+    assertThatThrownBy(() -> companionRegistry.register(payload))
+      .isInstanceOf(BadRequestException.class)
+      .satisfies(e -> assertThat(((BadRequestException) e).getStatusCode()).isEqualTo(400));
+  }
+
+  @Test
+  void should_reject_registration_with_an_invalid_port() {
+    JsonObject payload = payload("mscgen").put("port", 0);
+    assertThatThrownBy(() -> companionRegistry.register(payload))
+      .isInstanceOf(BadRequestException.class)
+      .satisfies(e -> assertThat(((BadRequestException) e).getStatusCode()).isEqualTo(400));
+  }
+
+  @Test
+  void should_reject_registration_with_a_non_numeric_port() {
+    JsonObject payload = payload("mscgen").put("port", "8080");
+    assertThatThrownBy(() -> companionRegistry.register(payload))
+      .isInstanceOf(BadRequestException.class)
+      .satisfies(e -> assertThat(((BadRequestException) e).getStatusCode()).isEqualTo(400));
+  }
+
+  @Test
+  void should_reject_registration_with_a_non_array_formats() {
+    JsonObject payload = payload("mscgen").put("formats", "svg");
+    assertThatThrownBy(() -> companionRegistry.register(payload))
+      .isInstanceOf(BadRequestException.class)
+      .satisfies(e -> assertThat(((BadRequestException) e).getStatusCode()).isEqualTo(400));
+  }
+
+  @Test
+  void should_reject_registration_targeting_a_cloud_metadata_endpoint() {
+    JsonObject payload = payload("mscgen").put("host", "169.254.169.254");
+    assertThatThrownBy(() -> companionRegistry.register(payload))
+      .isInstanceOf(BadRequestException.class)
+      .satisfies(e -> assertThat(((BadRequestException) e).getStatusCode()).isEqualTo(400));
+  }
+
+  @Test
+  void should_reject_registration_targeting_a_cloud_metadata_endpoint_with_a_trailing_dot() {
+    // "169.254.169.254." (trailing dot) resolves identically to the bare IP for practically every
+    // DNS resolver and HTTP client, and must not bypass the denylist's exact string match
+    JsonObject payload = payload("mscgen").put("host", "169.254.169.254.");
+    assertThatThrownBy(() -> companionRegistry.register(payload))
+      .isInstanceOf(BadRequestException.class)
+      .satisfies(e -> assertThat(((BadRequestException) e).getStatusCode()).isEqualTo(400));
+  }
+
+  @Test
+  void should_reject_registration_targeting_a_non_ip_cloud_metadata_hostname() {
+    JsonObject payload = payload("mscgen").put("host", "metadata.google.internal");
+    assertThatThrownBy(() -> companionRegistry.register(payload))
+      .isInstanceOf(BadRequestException.class)
+      .satisfies(e -> assertThat(((BadRequestException) e).getStatusCode()).isEqualTo(400));
+  }
+
+  @Test
+  void should_reject_registration_targeting_a_loopback_address() {
+    JsonObject payload = payload("mscgen").put("host", "127.0.0.1");
+    assertThatThrownBy(() -> companionRegistry.register(payload))
+      .isInstanceOf(BadRequestException.class)
+      .satisfies(e -> assertThat(((BadRequestException) e).getStatusCode()).isEqualTo(400));
+  }
+
+  @Test
+  void should_reject_registration_targeting_a_private_address() {
+    JsonObject payload = payload("mscgen").put("host", "10.0.0.5");
+    assertThatThrownBy(() -> companionRegistry.register(payload))
+      .isInstanceOf(BadRequestException.class)
+      .satisfies(e -> assertThat(((BadRequestException) e).getStatusCode()).isEqualTo(400));
+  }
+
+  @Test
+  void should_allow_registration_targeting_a_regular_hostname() {
+    // must not trigger a DNS lookup (which would block the event loop) to classify a plain hostname
+    CompanionRegistration registration = companionRegistry.register(payload("mscgen").put("host", "mscgen-companion.internal"));
+    assertThat(registration.getHost()).isEqualTo("mscgen-companion.internal");
+  }
+
+  @Test
+  void should_reject_registration_targeting_a_configured_extra_blocked_host() {
+    CompanionRegistry withExtraDenylist = new CompanionRegistry(diagramRegistry, new Delegator(vertx), Set.of("metadata.internal.example.com"));
+    JsonObject payload = payload("mscgen").put("host", "metadata.internal.example.com");
+    assertThatThrownBy(() -> withExtraDenylist.register(payload))
+      .isInstanceOf(BadRequestException.class)
+      .satisfies(e -> assertThat(((BadRequestException) e).getStatusCode()).isEqualTo(400));
+  }
+
+  @Test
+  void should_heartbeat_a_registered_service() {
+    companionRegistry.register(payload("mscgen"));
+    assertThat(companionRegistry.heartbeat("mscgen")).isPresent();
+  }
+
+  @Test
+  void should_return_empty_when_heartbeating_an_unregistered_service() {
+    assertThat(companionRegistry.heartbeat("mscgen")).isEmpty();
+  }
+
+  @Test
+  void should_unregister_a_service_and_free_up_its_name() {
+    companionRegistry.register(payload("mscgen"));
+    assertThat(companionRegistry.unregister("mscgen")).isTrue();
+    assertThat(diagramRegistry.isRegistered("mscgen")).isFalse();
+    assertThat(companionRegistry.get("mscgen")).isEmpty();
+    // the name should be free to register again
+    companionRegistry.register(payload("mscgen"));
+    assertThat(companionRegistry.get("mscgen")).isPresent();
+  }
+
+  @Test
+  void should_return_false_when_unregistering_an_unknown_service() {
+    assertThat(companionRegistry.unregister("mscgen")).isFalse();
+  }
+
+  @Test
+  void should_evict_services_that_missed_their_heartbeat_deadline() {
+    companionRegistry.register(payload("mscgen"));
+    List<String> expired = companionRegistry.sweepExpired(Duration.ofSeconds(-1));
+    assertThat(expired).containsExactly("mscgen");
+    assertThat(diagramRegistry.isRegistered("mscgen")).isFalse();
+  }
+
+  @Test
+  void should_not_evict_services_within_their_heartbeat_ttl() {
+    companionRegistry.register(payload("mscgen"));
+    List<String> expired = companionRegistry.sweepExpired(Duration.ofMinutes(5));
+    assertThat(expired).isEmpty();
+    assertThat(diagramRegistry.isRegistered("mscgen")).isTrue();
+  }
+
+  @Test
+  void should_list_registered_services() {
+    companionRegistry.register(payload("mscgen"));
+    companionRegistry.register(payload("nomnoml2"));
+    assertThat(companionRegistry.list()).extracting(CompanionRegistration::getName)
+      .containsExactlyInAnyOrder("mscgen", "nomnoml2");
+  }
+
+  private static class FakeDiagramService implements DiagramService {
+    @Override
+    public List<FileFormat> getSupportedFormats() {
+      return Collections.singletonList(FileFormat.SVG);
+    }
+
+    @Override
+    public SourceDecoder getSourceDecoder() {
+      return new SourceDecoder() {
+        @Override
+        public String decode(String encoded) {
+          return encoded;
+        }
+      };
+    }
+
+    @Override
+    public String getVersion() {
+      return "1.0.0";
+    }
+
+    @Override
+    public Future<Buffer> convert(String sourceDecoded, String serviceName, FileFormat fileFormat, JsonObject options) {
+      return Future.succeededFuture(Buffer.buffer());
+    }
+  }
+}


### PR DESCRIPTION
- Let a companion container not built into Kroki register itself as a new diagram type via a REST API under `/services` (register, heartbeat, get, list, unregister) — closes #1423
- Registrations are held in memory and expire without a heartbeat, since Kroki is stateless
- Disabled by default (`KROKI_ENABLE_COMPANION_DISCOVERY`), and always disabled under `KROKI_SAFE_MODE=SECURE` (the default, including on kroki.io) regardless of that flag
- The registration API can be gated with a bearer token (`KROKI_COMPANION_REGISTRATION_TOKEN`), and the host/port denylist (loopback, link-local, private addresses, cloud metadata hostnames) can be extended per deployment (`KROKI_COMPANION_BLOCKED_HOSTS`)
- `/health`, `/v1/health`, `/healthz` and the homepage now reflect the live registry instead of a startup snapshot