### PR TITLE
ci: restrict default GITHUB_TOKEN permissions per workflow

### DIFF
--- a/.github/workflows/cve-scan.yml
+++ b/.github/workflows/cve-scan.yml
@@ -3,6 +3,7 @@ on:
   schedule:
     - cron: '0 0 * * *'
   workflow_dispatch: { }
+permissions: {}
 jobs:
   scan-images:
     name: Scan latest public image

--- a/.github/workflows/dockerhub-description.yml
+++ b/.github/workflows/dockerhub-description.yml
@@ -5,6 +5,8 @@ on:
     tags:
       - 'v*'
       - .github/workflows/dockerhub-description.yml
+permissions:
+  contents: read
 jobs:
   docker-hub-description:
     runs-on: ubuntu-latest

--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -13,6 +13,9 @@ on:
       - '*'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   test-kind-multipod:
     runs-on: ubuntu-latest

--- a/.github/workflows/docs-notify.yml
+++ b/.github/workflows/docs-notify.yml
@@ -7,6 +7,8 @@ on:
     branches:
       - main
 
+permissions: {}
+
 jobs:
   trigger_publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -18,6 +18,9 @@ on:
         required: true
         type: boolean
 
+permissions:
+  contents: read
+
 jobs:
   test-containers:
     runs-on: ubuntu-24.04

--- a/.github/workflows/mermaid-ci.yaml
+++ b/.github/workflows/mermaid-ci.yaml
@@ -14,6 +14,9 @@ on:
     branches:
       - '*'
 
+permissions:
+  contents: read
+
 jobs:
   mermaid-ci:
     runs-on: ubuntu-latest

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -4,6 +4,9 @@ on:
   schedule:
     - cron: '0 2 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   test-containers-multiarch:
     uses: ./.github/workflows/main.yaml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,9 @@ on:
         default: true
         type: boolean
 
+permissions:
+  contents: write
+
 jobs:
   release:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
Adds an explicit top-level permissions block to every workflow, addressing GitHub's "Workflow does not contain permissions" warning. Most workflows only need contents: read (or no permissions at all); release.yml needs contents: write since it pushes tags/commits and creates GitHub releases.